### PR TITLE
recast variable type in c++ to avoid overflow

### DIFF
--- a/pecos/core/utils/matrix.hpp
+++ b/pecos/core/utils/matrix.hpp
@@ -228,7 +228,7 @@ namespace pecos {
 
         // Construct a csr_t object with shape _rows x _cols filled by 1.
         void fill_ones(index_type _rows, index_type _cols) {
-            mem_index_type nnz = _rows * _cols;
+            mem_index_type nnz = (mem_index_type) _rows * _cols;
             this->allocate(_rows, _cols, nnz);
 
             row_ptr[0] = 0;
@@ -343,7 +343,7 @@ namespace pecos {
 
         // Construct a csc_t object with shape _rows x _cols filled by 1.
         void fill_ones(index_type _rows, index_type _cols) {
-            mem_index_type nnz = _rows * _cols;
+            mem_index_type nnz = (mem_index_type) _rows * _cols;
             this->free_underlying_memory();
             this->allocate(_rows, _cols, nnz);
             col_ptr[0] = 0;

--- a/pecos/core/xmc/linear_solver.hpp
+++ b/pecos/core/xmc/linear_solver.hpp
@@ -161,7 +161,7 @@ struct SVMWorker {
 
             const auto& xi = X.get_row(i);
             QD[i] += do_dot_product(xi, xi) + (param.bias > 0 ? param.bias * param.bias : 0);
-            double coef = inst_info[i].y * alpha[i];
+            double coef = (double) inst_info[i].y * alpha[i];
             do_axpy(coef, xi, curr_w);
             b += (param.bias > 0 ? coef * param.bias : 0);
         }
@@ -276,7 +276,7 @@ struct SVMWorker {
 
             const auto& xi = X.get_row(i);
             xTx[i] = do_dot_product(xi, xi) + (param.bias > 0 ? param.bias * param.bias : 0);
-            double coef = inst_info[i].y * alpha[2 * i];
+            double coef = (double) inst_info[i].y * alpha[2 * i];
             do_axpy(coef, xi, curr_w);
             b += (param.bias > 0 ? coef * param.bias : 0);
         }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
- issue: Code-scanning suggests some potential overflow in c++ due to improper type casting (e.g., [link](https://github.com/amzn/pecos/security/code-scanning/4?query=ref%3Arefs%2Fheads%2Fmainline)).
- fixed it by explicitly type recasting.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.