### PR TITLE
Single-source style/type/unittest in GitActions

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -23,9 +23,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install pip
-        python -m pip install --upgrade pip
-        pip install pytest pytest-coverage
-        pip install -v --editable .
+        make libpecos VFLAG=-v
     - name: Test with pytest
       run: |
-        pytest
+        make test VFLAG=-v

--- a/.github/workflows/style_type_check.yml
+++ b/.github/workflows/style_type_check.yml
@@ -20,15 +20,12 @@ jobs:
     - name: Black checks
       run: |
         pip install black
-        python -m black -v --check --diff --config .github/style_type_check_cfg/.black ./pecos
-        python -m black -v --check --diff --config .github/style_type_check_cfg/.black ./test
+        make black VFLAG=-v
     - name: Flake8 checks
       run: |
         pip install flake8
-        python -m flake8 -v --config .github/style_type_check_cfg/.flake8 ./pecos
-        python -m flake8 -v --config .github/style_type_check_cfg/.flake8 ./test
+        make flake8 VFLAG=-v
     - name: Mypy checks
       run: |
         pip install mypy
-        python -m mypy -v --config-file .github/style_type_check_cfg/.mypy -p pecos
-        python -m mypy -v --config-file .github/style_type_check_cfg/.mypy `find ./test/ -type f -name "*.py"`
+        make mypy VFLAG=-v


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Single-source the style/type check and unit-test commands in Git Actions, by using Makefile and associated targets.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.