### PR TITLE
Check HLM.set_output_constraint() input argument is set type variable.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,11 +41,18 @@ To send us a pull request, please:
     git pull -r upstream mainline
     ```
 4. Create a new branch from `mainline` to work on, or rebase your working branch on newest `mainline`.
+    ```
+    git checkout -b <BRANCH NAME>
+    ```
 5. Implement your code on the new branch:
     * Follow the code style of the project.
     * Write or adapt tests as needed.
     * Add or change the documentation as needed.
-6. **Ensure local style/type checks and tests pass.** You can use the `Makefile` commands to check:
+6. **Ensure local style/type checks and tests pass.** First ensure you install the following for style-checking and unit-testing
+    ```
+	pip install flake8 black mypy
+    ```
+	Then you can use the `Makefile` commands to check:
     ```
     make clean
     make format

--- a/pecos/xmc/base.py
+++ b/pecos/xmc/base.py
@@ -1423,6 +1423,10 @@ class HierarchicalMLModel(pecos.BaseClass):
         """
         if self.is_predict_only:
             raise Exception("Model is predict only! set_output_constraint not supported!")
+        try:
+            labels_to_keep = set(labels_to_keep)
+        except TypeError:
+            raise TypeError("can not convert labels_to_keep as set variable type!")
 
         for cur_dep, cur_model in enumerate(self.model_chain[::-1]):
             if len(labels_to_keep) == cur_model.C.shape[0]:


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
(1) Convert the input argument `labels_to_keep` in `HierarchicalMLModel.set_output_constraint()` function to be a set variable type. Raise `TypeError` is not success.
(2) Update `CONTRIBUTION.md` about the prerequisite packages `flake8`, `black`, and `mypy` for style-checking and unit-testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.