### PR TITLE
avoid ensemble for text2text prediction with sinlge model

### DIFF
--- a/pecos/apps/text2text/model.py
+++ b/pecos/apps/text2text/model.py
@@ -416,14 +416,18 @@ class Text2Text(object):
         """
 
         X = self.preprocessor.predict(corpus)
-        Y_pred = smat_util.CsrEnsembler.average(
-            *[
-                m.predict(
-                    X, only_topk=topk, beam_size=beam_size, post_processor=post_processor, **kwargs
-                )
-                for m, _ in self.xlinear_models
-            ]
-        )
+
+        Y_pred = [
+            m.predict(
+                X, only_topk=topk, beam_size=beam_size, post_processor=post_processor, **kwargs
+            )
+            for m, _ in self.xlinear_models
+        ]
+
+        if len(Y_pred) > 1:
+            Y_pred = smat_util.CsrEnsembler.average(*Y_pred)
+        else:
+            Y_pred = Y_pred[0]
 
         if threshold is not None:
             Y_pred.data[Y_pred.data <= threshold] = 0


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Avoids passing through `CsrEnsembler` when `Text2Text` only contains one model. This will reduce the overhead of unnecessary matrix operations and increase inference speed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.