### PR TITLE
Improve error message for installation in non-git repo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,10 @@ __version__ = "%s"
         """Update version from git tag infomation.
         If git tag missing, will use a dummy version 0.0.0
         """
-        assert os.path.isdir(".git"), "This does not appear to be a Git repository."
+        if not os.path.isdir(".git"):
+            raise RuntimeError("PECOS install should be inside a Git repository. " + \
+                "Either clone source from GitHub by `git clone https://github.com/amzn/pecos.git` " + \
+                "or run `git init` for GitHub downloaded zip source files before installing.")
 
         # Run git describe to get current tag, commit hash is not included
         git_desc = subprocess.run(["git", "describe", "--tags", "--abbrev=0"],


### PR DESCRIPTION
*Issue #, if available:*
#17 

*Description of changes:*
Added detailed error message for installing PECOS from a non-git repository to better guide users.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.