### PR TITLE
Added support for predicting on select outputs

### DIFF
--- a/pecos/xmc/base.py
+++ b/pecos/xmc/base.py
@@ -21,7 +21,14 @@ import dataclasses as dc
 import numpy as np
 import pecos
 import scipy.sparse as smat
-from pecos.core import ScipyCompressedSparseAllocator, ScipyCscF32, ScipyCsrF32, ScipyDrmF32, clib
+from pecos.core import (
+    ScipyCompressedSparseAllocator,
+    ScipyCscF32,
+    ScipyCsrF32,
+    ScipyDrmF32,
+    clib,
+    XLINEAR_INFERENCE_MODEL_TYPES,
+)
 from pecos.utils import smat_util
 from pecos.utils.cluster_util import ClusterChain, hierarchical_kmeans
 from sklearn.preprocessing import normalize
@@ -818,6 +825,61 @@ class MLModel(pecos.BaseClass):
 
         return pred_alloc.get()
 
+    def predict_select_outputs(
+        self,
+        X,
+        select_outputs_csr,
+        csr_codes=None,
+        pred_params=None,
+        **kwargs,
+    ):
+        """Predict on given input data
+
+        Args:
+            X (csr_matrix or ndarray): instance feature matrix to predict on
+            select_outputs_csr (csr_matrix): the select outputs to predict
+            csr_codes (csr_matrix): the prediction from previous matchers (nr_inst, nr_codes).
+                Default None to ignore
+            pred_params (MLModel.PredParams, optional): instance of MLModel.PredParams.
+                Default None to use the pred_params used in model training.
+            kwargs: overriding prediction parameters for backward compatibility
+                post_processor (str, optional):  override the post_processor in pred_params
+                    Default None to disable overriding
+                threads (int, optional): override the number of threads to use for training in pred_params
+                    Default to -1 to disable overriding
+
+        Returns:
+            pred_csr (csr_matrix): prediction matrix (nr_inst, nr_labels)
+        """
+        if X.shape[1] != self.nr_features:
+            raise ValueError("Feature dimension of query matrix does not match weight matrix")
+        if X.shape[0] != select_outputs_csr.shape[0]:
+            raise ValueError("Instance dimension of query and select output matrix do not match")
+
+        if select_outputs_csr.shape[1] != self.nr_labels:
+            raise ValueError("Label dimension of select output matrix does not match")
+
+        pred_params = self.get_pred_params() if pred_params is None else pred_params
+        pred_params.override_with_kwargs(kwargs)
+        if not pred_params.is_valid():
+            raise ValueError("pred_params is not valid!")
+
+        pred_alloc = ScipyCompressedSparseAllocator()
+
+        clib.xlinear_single_layer_predict_select_outputs(
+            X,
+            select_outputs_csr,
+            csr_codes,
+            self.W,
+            self.C,
+            pred_params.post_processor,
+            kwargs.get("threads", -1),
+            self.bias,
+            pred_alloc,
+        )
+
+        return pred_alloc.get()
+
     def get_submodel(self, selected_codes=None, selected_labels=None, reindex=False):
         """Slice/sparsify the model based on connections to given code and labels.
 
@@ -1051,6 +1113,26 @@ class HierarchicalMLModel(pecos.BaseClass):
             return clib.xlinear_get_int_attr(self.model_chain, "nr_labels")
         else:
             return self.model_chain[-1].nr_labels
+
+    def get_weight_matrix_type(self, layer_depth):
+        """Get the weight matrix type of a layer at a certain depth
+
+        Args:
+            layer_depth (int): The depth of the layer type to get
+
+        Returns:
+            weight_matrix_type (string): If is_predict_only=True, the weight matrix type of
+                the specified layer is returned. Otherwise if is_predict_only=False, the default
+                type "CSC" is returned.
+
+        """
+        if self.is_predict_only:
+            weight_matrix_value = clib.xlinear_get_layer_type(self.model_chain, layer_depth)
+            return list(XLINEAR_INFERENCE_MODEL_TYPES.keys())[
+                list(XLINEAR_INFERENCE_MODEL_TYPES.values()).index(weight_matrix_value)
+            ]
+        else:
+            return "CSC"
 
     def __add__(self, other):
         if self.is_predict_only:
@@ -1410,6 +1492,118 @@ class HierarchicalMLModel(pecos.BaseClass):
                 )
 
             return pred_csr
+
+    def predict_select_outputs(
+        self,
+        X,
+        select_outputs_csr,
+        pred_params=None,
+        **kwargs,
+    ):
+        """Predict on given input data
+        Args:
+            X (csr_matrix or ndarray): instance feature matrix to predict on
+            select_outputs_csr (csr_matrix): the select outputs to predict
+            pred_params (HierarchicalMLModel.PredParams, optional): instance of HierarchicalMLModel.PredParams.
+                Default None to use the pred_params used in model training.
+            kwargs: overriding prediction parameters for backward compatibility
+                post_processor (str, optional):  override the post_processor specified in pred_params (all layers)
+                    Default None to disable overriding
+                threads (int, optional): the number of threads to use for training.
+                    Defaults to -1 to use all
+        Returns:
+            pred_csr (csr_matrix): prediction matrix (nr_inst, nr_labels)
+        """
+        if X.dtype != np.float32:
+            raise ValueError("X.dtype = {} is not supported".format(X.dtype))
+        if not isinstance(X, smat.csr_matrix) and not (
+            isinstance(X, np.ndarray) and X.flags["C_CONTIGUOUS"]
+        ):
+            raise ValueError("type(X) = {} is not supported".format(type(X)))
+        if X.shape[1] != self.nr_features:
+            raise ValueError("Feature dimension of query matrix does not match weight matrix")
+
+        if not isinstance(select_outputs_csr, smat.csr_matrix):
+            raise ValueError(
+                "type(select_outputs_csr) = {} is not supported".format(type(select_outputs_csr))
+            )
+        if select_outputs_csr.shape[1] != self.nr_labels:
+            raise ValueError("Label dimension of select output matrix does not match")
+
+        if X.shape[0] != select_outputs_csr.shape[0]:
+            raise ValueError("Instance dimension of query and select output matrix do not match")
+
+        # construct pred_params
+        if pred_params is None:
+            pred_params = self.get_pred_params()
+        elif isinstance(pred_params, self.PredParams):
+            pred_params = self.PredParams.from_dict(pred_params)
+            pred_params = self._duplicate_fields_with_name_ending_with_chain(
+                pred_params, self.PredParams, self.depth
+            )
+        else:
+            raise ValueError("unknown type(pred_params)!!")
+        pred_params.override_with_kwargs(kwargs)
+
+        if self.is_predict_only:
+            for layer_depth in range(self.depth):
+                if self.get_weight_matrix_type(layer_depth) != "CSC":
+                    raise NotImplementedError(
+                        "is_predict_only=True not supported for weight_matrix_type = {}".format(
+                            self.weight_matrix_type
+                        )
+                    )
+
+            old_chain = self.get_pred_params().model_chain
+            new_chain = pred_params.model_chain
+
+            # check if post_processor is valid (support by C++) after overriding
+            if all(
+                old_p.post_processor == new_p.post_processor
+                for (old_p, new_p) in zip(old_chain, new_chain)
+            ):
+                overridden_post_processor = None
+            elif all(new_chain[0].post_processor == new_p.post_processor for new_p in new_chain):
+                overridden_post_processor = new_chain[0].post_processor
+            else:
+                raise NotImplementedError(
+                    "when is_predict_only=True, post_processor is not supported for overriddng"
+                )
+
+            # Call C++ code
+            pred_alloc = ScipyCompressedSparseAllocator()
+            clib.xlinear_predict_select_outputs(
+                self.model_chain,
+                X,
+                select_outputs_csr,
+                overridden_post_processor,
+                kwargs.get("threads", -1),
+                pred_alloc,
+            )
+
+            return pred_alloc.get()
+        else:
+            select_outputs_csrs = []
+            select_outputs_csrs.insert(0, select_outputs_csr)
+            for d in range(self.depth - 2, -1, -1):
+                prev_csr = clib.sparse_matmul(
+                    select_outputs_csrs[0],
+                    self.model_chain[d + 1].C,
+                    threads=kwargs.get("threads", -1),
+                ).tocsr()
+                select_outputs_csrs.insert(0, prev_csr)
+
+            prev_pred_csr = None
+            for d in range(self.depth):
+                prev_pred_csr = self.model_chain[d].predict_select_outputs(
+                    X=X,
+                    select_outputs_csr=select_outputs_csrs[d],
+                    csr_codes=prev_pred_csr,
+                    pred_params=pred_params.model_chain[d],
+                    threads=kwargs.get("threads", -1),
+                )
+
+            return prev_pred_csr
 
     def set_output_constraint(self, labels_to_keep):
         """

--- a/pecos/xmc/xlinear/model.py
+++ b/pecos/xmc/xlinear/model.py
@@ -359,6 +359,7 @@ class XLinearModel(pecos.BaseClass):
         self,
         X,
         pred_params=None,
+        select_outputs_csr=None,
         **kwargs,
     ):
         """Predict on given input data
@@ -366,6 +367,9 @@ class XLinearModel(pecos.BaseClass):
         Args:
             X (csr_matrix(float32) or ndarray(float32)): instance feature matrix to predict on
             pred_params (XLinearModel.PredParams, optional): instance of XLinearModel.PredParams
+            select_outputs_csr (csr_matrix, optional): instance label matrix to predict from with
+                shape (instances, labels). Interested labels to predict are denoted only by indices
+                with a nonzero value.
             kwargs:
                 beam_size (int, optional): override the beam size specified in the model.
                     Default None to disable overriding
@@ -377,12 +381,26 @@ class XLinearModel(pecos.BaseClass):
                     Defaults to -1 to use all
 
         Returns:
-            Y_pred (csr_matrix): prediction matrix
+            Y_pred (csr_matrix): If a select output matrix is provided, the prediction for the
+                indicated output is returned. Otherwise, a prediction matrix for some topk
+                scores is returned.
         """
-        if pred_params is None:
-            Y_pred = self.model.predict(X, pred_params=None, **kwargs)
-        elif isinstance(pred_params, self.PredParams):
-            Y_pred = self.model.predict(X, pred_params=pred_params.hlm_args, **kwargs)
+        if select_outputs_csr is None:
+            if pred_params is None:
+                Y_pred = self.model.predict(X, pred_params=None, **kwargs)
+            elif isinstance(pred_params, self.PredParams):
+                Y_pred = self.model.predict(X, pred_params=pred_params.hlm_args, **kwargs)
+            else:
+                raise TypeError("type(pred_kwargs) is not supported")
         else:
-            raise TypeError("type(pred_kwargs) is not supported")
+            if pred_params is None:
+                Y_pred = self.model.predict_select_outputs(
+                    X, select_outputs_csr, pred_params=None, **kwargs
+                )
+            elif isinstance(pred_params, self.PredParams):
+                Y_pred = self.model.predict_select_outputs(
+                    X, select_outputs_csr, pred_params=pred_params.hlm_args, **kwargs
+                )
+            else:
+                raise TypeError("type(pred_kwargs) is not supported")
         return Y_pred

--- a/pecos/xmc/xlinear/predict.py
+++ b/pecos/xmc/xlinear/predict.py
@@ -103,6 +103,15 @@ def parse_arguments():
         metavar="THREADS",
         help="number of threads to use (default -1 to denote all the CPUs)",
     )
+
+    parser.add_argument(
+        "-so",
+        "--select-output",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help="path to the npz file of the select output matrix (CSR, nr_insts * nr_labels), only-topk and beam-size are ignored if given",
+    )
     return parser
 
 
@@ -116,14 +125,26 @@ def do_predict(args):
     # Load data
     Xt = XLinearModel.load_feature_matrix(args.inst_path)
 
-    # Model Predicting
-    xlinear_model = XLinearModel.load(args.model_folder, is_predict_only=True)
+    if args.select_output is not None:
+        # Select Output
+        select_outputs_csr = XLinearModel.load_feature_matrix(args.select_output)
+        xlinear_model = XLinearModel.load(
+            args.model_folder, is_predict_only=True, weight_matrix_type="CSC"
+        )
+    else:
+        # TopK
+        select_outputs_csr = None
+        xlinear_model = XLinearModel.load(args.model_folder, is_predict_only=True)
 
+    # Model Predicting
     if args.batch_size is not None:
         Yts = []
         for i in range(0, Xt.shape[0], args.batch_size):
             Yte = xlinear_model.predict(
                 Xt[i : i + args.batch_size, :],
+                select_outputs_csr=select_outputs_csr[i : i + args.batch_size, :]
+                if select_outputs_csr is not None
+                else None,
                 only_topk=args.only_topk,
                 beam_size=args.beam_size,
                 post_processor=args.post_processor,
@@ -135,6 +156,7 @@ def do_predict(args):
     else:
         Yt_pred = xlinear_model.predict(
             Xt,
+            select_outputs_csr=select_outputs_csr,
             only_topk=args.only_topk,
             beam_size=args.beam_size,
             post_processor=args.post_processor,

--- a/test/pecos/xmc/xlinear/test_xlinear.py
+++ b/test/pecos/xmc/xlinear/test_xlinear.py
@@ -240,6 +240,22 @@ def test_cli(tmpdir):
         Yt_pred = smat_util.load_matrix(test_Y_pred_file)
         assert Yt_pred.todense() == approx(true_Yt_pred.todense(), abs=1e-6)
 
+        # Select Inference
+        cmd = []
+        cmd += ["python3 -m pecos.xmc.xlinear.predict"]
+        cmd += ["-x {}".format(test_X)]
+        cmd += ["-y {}".format(test_Y_file)]
+        cmd += ["-so {}".format(true_Y_pred_file)]
+        cmd += ["-o {}".format(test_Y_pred_file)]
+        cmd += ["-m {}".format(model_folder)]
+        process = subprocess.run(
+            shlex.split(" ".join(cmd)), stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        assert process.returncode == 0, " ".join(cmd)
+        true_Yt_pred = smat_util.load_matrix(true_Y_pred_file)
+        Yt_select_pred = smat_util.load_matrix(test_Y_pred_file)
+        assert Yt_select_pred.todense() == approx(true_Yt_pred.todense(), abs=1e-6)
+
         # Evaluate
         cmd = []
         cmd += ["python3 -m pecos.xmc.xlinear.evaluate"]
@@ -300,6 +316,22 @@ def test_cli(tmpdir):
         Yt_pred = smat_util.load_matrix(test_Y_pred_file)
         assert Yt_pred.todense() == approx(true_Yt_pred.todense(), abs=1e-6)
 
+        # Select Inference
+        cmd = []
+        cmd += ["python3 -m pecos.xmc.xlinear.predict"]
+        cmd += ["-x {}".format(test_X)]
+        cmd += ["-y {}".format(test_Y_file)]
+        cmd += ["-so {}".format(true_Y_pred_file)]
+        cmd += ["-o {}".format(test_Y_pred_file)]
+        cmd += ["-m {}".format(model_folder)]
+        process = subprocess.run(
+            shlex.split(" ".join(cmd)), stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        assert process.returncode == 0, " ".join(cmd)
+        true_Yt_pred = smat_util.load_matrix(true_Y_pred_file)
+        Yt_select_pred = smat_util.load_matrix(test_Y_pred_file)
+        assert Yt_select_pred.todense() == approx(true_Yt_pred.todense(), abs=1e-6)
+
         # Training with User Supplied Negative
         M = (Y * C).tocsc()
         smat.save_npz(match_file, M)
@@ -321,6 +353,22 @@ def test_cli(tmpdir):
         cmd += ["python3 -m pecos.xmc.xlinear.predict"]
         cmd += ["-x {}".format(test_X)]
         cmd += ["-y {}".format(test_Y_file)]
+        cmd += ["-o {}".format(test_Y_pred_file)]
+        cmd += ["-m {}".format(model_folder)]
+        process = subprocess.run(
+            shlex.split(" ".join(cmd)), stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        assert process.returncode == 0, " ".join(cmd)
+        true_Yt_pred = smat_util.load_matrix(true_Y_pred_file)
+        Yt_pred = smat_util.load_matrix(test_Y_pred_file)
+        assert Yt_pred.todense() == approx(true_Yt_pred.todense(), abs=1e-6)
+
+        # Select Inference
+        cmd = []
+        cmd += ["python3 -m pecos.xmc.xlinear.predict"]
+        cmd += ["-x {}".format(test_X)]
+        cmd += ["-y {}".format(test_Y_file)]
+        cmd += ["-so {}".format(true_Y_pred_file)]
         cmd += ["-o {}".format(test_Y_pred_file)]
         cmd += ["-m {}".format(model_folder)]
         process = subprocess.run(
@@ -374,6 +422,24 @@ def test_cli(tmpdir):
         Yt_pred = smat_util.load_matrix(test_Y_pred_file)
         assert Yt_pred.todense() == approx(true_Yt_pred_with_man.todense(), abs=1e-6)
 
+        # Select Inference
+        cmd = []
+        cmd += ["python3 -m pecos.xmc.xlinear.predict"]
+        cmd += ["-x {}".format(test_X)]
+        cmd += ["-y {}".format(test_Y_file)]
+        cmd += ["-so {}".format(true_Y_pred_with_man_file)]
+        cmd += ["-o {}".format(test_Y_pred_file)]
+        cmd += ["-m {}".format(model_folder)]
+        cmd += ["-pp sigmoid"]
+        cmd += ["-b 4"]
+        process = subprocess.run(
+            shlex.split(" ".join(cmd)), stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        assert process.returncode == 0, " ".join(cmd)
+        true_Yt_pred_with_man = smat_util.load_matrix(true_Y_pred_with_man_file)
+        Yt_select_pred = smat_util.load_matrix(test_Y_pred_file)
+        assert Yt_select_pred.todense() == approx(true_Yt_pred_with_man.todense(), abs=1e-6)
+
         # Training with Matcher Aware Negatives
         cmd = []
         cmd += ["python3 -m pecos.xmc.xlinear.train"]
@@ -404,6 +470,24 @@ def test_cli(tmpdir):
         true_Yt_pred_with_man = smat_util.load_matrix(true_Y_pred_with_man_file)
         Yt_pred = smat_util.load_matrix(test_Y_pred_file)
         assert Yt_pred.todense() == approx(true_Yt_pred_with_man.todense(), abs=1e-6)
+
+        # Select Inference
+        cmd = []
+        cmd += ["python3 -m pecos.xmc.xlinear.predict"]
+        cmd += ["-x {}".format(test_X)]
+        cmd += ["-y {}".format(test_Y_file)]
+        cmd += ["-so {}".format(true_Y_pred_with_man_file)]
+        cmd += ["-o {}".format(test_Y_pred_file)]
+        cmd += ["-m {}".format(model_folder)]
+        cmd += ["-pp sigmoid"]
+        cmd += ["-b 4"]
+        process = subprocess.run(
+            shlex.split(" ".join(cmd)), stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        assert process.returncode == 0, " ".join(cmd)
+        true_Yt_pred_with_man = smat_util.load_matrix(true_Y_pred_with_man_file)
+        Yt_select_pred = smat_util.load_matrix(test_Y_pred_file)
+        assert Yt_select_pred.todense() == approx(true_Yt_pred_with_man.todense(), abs=1e-6)
 
         # Training with various number of splits to construct hierarchy
         for splits in [2, 4]:
@@ -438,6 +522,24 @@ def test_cli(tmpdir):
             true_Yt_pred = smat_util.load_matrix(true_Yt_pred_with_splits[splits])
             Yt_pred = smat_util.load_matrix(test_Y_pred_file)
             assert Yt_pred.todense() == approx(true_Yt_pred.todense(), abs=1e-6)
+
+            cmd = []
+            cmd += ["python3 -m pecos.xmc.xlinear.predict"]
+            cmd += [f"-x {test_X}"]
+            cmd += [f"-y {test_Y_file}"]
+            cmd += [f"-so {true_Yt_pred_with_splits[splits]}"]
+            cmd += [f"-m {model_folder_local}"]
+            cmd += [f"-o {test_Y_pred_file}"]
+            cmd += [f"-B 2"]
+
+            process = subprocess.run(
+                shlex.split(" ".join(cmd)), stdout=subprocess.PIPE, stderr=subprocess.PIPE
+            )
+            assert process.returncode == 0, " ".join(cmd)
+
+            true_Yt_pred = smat_util.load_matrix(true_Yt_pred_with_splits[splits])
+            Yt_select_pred = smat_util.load_matrix(test_Y_pred_file)
+            assert Yt_select_pred.todense() == approx(true_Yt_pred.todense(), abs=1e-6)
 
 
 def test_split_model_at_depth():
@@ -743,3 +845,84 @@ def test_get_submodel():
     assert 0 in out["active_labels"]
     assert 1 in out["active_labels"]
     assert 3 in out["active_labels"]
+
+
+def test_predict_consistency_between_topk_and_select(tmpdir):
+    from pecos.xmc import PostProcessor, Indexer, LabelEmbeddingFactory
+    from pecos.xmc.xlinear import XLinearModel
+
+    train_X_file = "test/tst-data/xmc/xlinear/X.npz"
+    train_Y_file = "test/tst-data/xmc/xlinear/Y.npz"
+    test_X_file = "test/tst-data/xmc/xlinear/Xt.npz"
+    Xt = XLinearModel.load_feature_matrix(train_X_file)
+    Yt = XLinearModel.load_feature_matrix(train_Y_file)
+    model_folder = str(tmpdir.join("save_model"))
+    label_feat = LabelEmbeddingFactory.create(Yt, Xt, method="pifa")
+
+    model_folder_list = []
+    # Obtain xlinear models with vairous number of splits
+    for splits in [2, 4]:
+        model_folder_local = f"{model_folder}-{splits}"
+        cluster_chain = Indexer.gen(label_feat, nr_splits=splits)
+        py_model = XLinearModel.train(Xt, Yt, C=cluster_chain)
+        py_model.save(model_folder_local)
+        model_folder_list.append(model_folder_local)
+
+    X = XLinearModel.load_feature_matrix(test_X_file)
+
+    def test_on_model(model, X):
+        for pp in PostProcessor.valid_list():
+            # Batch mode topk
+            py_sparse_topk_pred = model.predict(X, post_processor=pp)
+            py_dense_topk_pred = model.predict(X.todense(), post_processor=pp)
+
+            # Sparse Input
+            py_select_sparse_topk_pred = model.predict(
+                X, select_outputs_csr=py_sparse_topk_pred, post_processor=pp
+            )
+            # Dense Input
+            py_select_dense_topk_pred = model.predict(
+                X.todense(), select_outputs_csr=py_dense_topk_pred, post_processor=pp
+            )
+
+            assert py_sparse_topk_pred.todense() == approx(
+                py_select_sparse_topk_pred.todense(), abs=1e-6
+            ), f"model:{model_folder_local} (batch, sparse, topk) post_processor:{pp})"
+            assert py_dense_topk_pred.todense() == approx(
+                py_select_dense_topk_pred.todense(), abs=1e-6
+            ), f"model:{model_folder_local} (batch, dense, topk) post_processor:{pp})"
+
+            # Realtime mode topk
+            for i in range(X.shape[0]):
+                query_slice = X[[i], :]
+                query_slice.sort_indices()
+
+                py_sparse_realtime_pred = model.predict(query_slice, post_processor=pp)
+                py_dense_realtime_pred = model.predict(query_slice.todense(), post_processor=pp)
+
+                # Sparse Input
+                py_select_sparse_realtime_pred = model.predict(
+                    query_slice, select_outputs_csr=py_sparse_realtime_pred, post_processor=pp
+                )
+                # Dense input
+                py_select_dense_realtime_pred = model.predict(
+                    query_slice.todense(),
+                    select_outputs_csr=py_dense_realtime_pred,
+                    post_processor=pp,
+                )
+
+                assert py_sparse_realtime_pred.todense() == approx(
+                    py_select_sparse_realtime_pred.todense(), abs=1e-6
+                ), f"model:{model_folder_local} (realtime, sparse, topk) post_processor:{pp}"
+                assert py_dense_realtime_pred.todense() == approx(
+                    py_select_dense_realtime_pred.todense(), abs=1e-6
+                ), f"model:{model_folder_local} (realtime, dense, topk) post_processor:{pp}"
+
+    for model_folder_local in model_folder_list:
+        model_f = XLinearModel.load(model_folder_local, is_predict_only=False)
+        model_t = XLinearModel.load(
+            model_folder_local, is_predict_only=True, weight_matrix_type="CSC"
+        )
+
+        test_on_model(model_f, X)
+        test_on_model(model_t, X)


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Added support for predicting and getting the scores for a set of interested labels. Interested labels are denoted by nonzero entries in an indicator matrix of shape (instances, labels).

An example of CLI usage for select output predict would be
``` sh
> python3 -m pecos.xmc.xlinear.predict -x ${X_path} -m ${model_dir} -so ${select_outputs_path} -o ${Yp_path}
```
where ```X_path``` is the path to the test feature matrix with shape (instances, features), ```model_dir``` is the path to the trained model, ```select_outputs_path``` is the path to the select outputs indicator matrix with shape (instances, labels), and ```Yp_path``` is the path to save the prediction label matrix with shape (instances, labels).

Two examples of Python API usage for loading a supported model would be 
```python
from pecos.xmc.xlinear import XLinearModel
model = XLinearModel.load("model_folder", is_predict_only=False)
```
and
```python
from pecos.xmc.xlinear import XLinearModel
model = XLinearModel.load("model_folder", is_predict_only=True, weight_matrix_type="CSC")
```
where ```model_folder``` is the path to the trained model.
Note that for is_predict_only=True only the weight_matrix_type "CSC" is currently supported.

An example of Python API usage for doing a select output predict on a model would be
``` python
from pecos.xmc.xlinear import XLinearModel
X = XLinearModel.load_feature_matrix("X.npz")
select_outputs = XLinearModel.load_feature_matrix("select_outputs.npz")
Y_pred = model.predict(Xt, select_outputs)
```
where ```X.npz``` is the path to the test feature matrix with shape (instances, features) and ```select_outputs.npz``` is the path to the select outputs indicator matrix with shape (instances, labels).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.