### PR TITLE
Remove Ubuntu-16.04 platform in GitAction and supported platforms description in README

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
-        platform: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
+        platform: [ubuntu-18.04, ubuntu-20.04]
 
     runs-on: ${{ matrix.platform }}
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You should install PECOS in a [virtual environment](https://docs.python.org/3/li
 If you're unfamiliar with Python virtual environments, check out the [user guide](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/).
 
 ### Supporting Platforms
-* Ubuntu 16.04, 18.04 and 20.04
+* Ubuntu 18.04 and 20.04
 * Amazon Linux 2
 
 ### Installation from Wheel
@@ -48,7 +48,7 @@ pip3 install libpecos
 ### Installation from Source
 
 #### Prerequisite builder tools
-* For Ubuntu (16.04, 18.04, 20.04):
+* For Ubuntu (18.04, 20.04):
 ``` bash
 apt-get update && apt-get install -y build-essential git python3 python3-distutils python3-venv
 ```


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Removed platform Ubuntu-16.04 in GitAction, as it will be removed on Sep, 20, 2021. (https://github.com/actions/virtual-environments/issues/3287)
Also removed Ubuntu-16.04 from description for PECOS supported platforms in README.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.