### PR TITLE
Refactor HNSW to reuse priority queues for different inference calls …

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ To send us a pull request, please:
     * Add or change the documentation as needed.
 6. **Ensure local style/type checks and tests pass.** First ensure you install the following for style-checking and unit-testing
     ```
-	pip install flake8 black mypy
+	python3 -m pip install flake8 black mypy
     ```
 	Then you can use the `Makefile` commands to check:
     ```

--- a/Makefile
+++ b/Makefile
@@ -41,12 +41,12 @@ mypy:
 # Install and unit test
 libpecos:
 	python3 -m pip install --upgrade pip
-	pip install ${VFLAG} --editable .
+	python3 -m pip install ${VFLAG} --editable .
 
 .PHONY: test
 test: libpecos
-	pip install pytest pytest-coverage
-	pytest
+	python3 -m pip install pytest pytest-coverage
+	python3 -m pytest
 
 # Clean
 clean:

--- a/pecos/core/ann/feat_vectors.hpp
+++ b/pecos/core/ann/feat_vectors.hpp
@@ -690,7 +690,7 @@ namespace ann {
             return 1.0 - ret;
         }
 
-        // a implementation faster than std::lower_bound
+        // an implementation faster than std::lower_bound
         template<class T>
         static T* lower_bound(T* first, T* last, const T& key) {
             intptr_t n = last - first;

--- a/pecos/core/base.py
+++ b/pecos/core/base.py
@@ -1532,8 +1532,8 @@ class corelib(object):
                     data_type_map[data_type],
                     c_uint32,  # M
                     c_uint32,  # efC
-                    c_uint32,  # max_level
                     c_int,  # threads
+                    c_int,  # max_level_upper_bound
                 ]
                 corelib.fillprototype(local_fn_dict[fn_name], res_list, arg_list)
 

--- a/pecos/core/libpecos.cpp
+++ b/pecos/core/libpecos.cpp
@@ -357,11 +357,11 @@ extern "C" {
         const PY_MAT* pX, \
         uint32_t M, \
         uint32_t efC, \
-        uint32_t max_level, \
-        int threads) { \
+        int threads, \
+        int max_level_upper_bound) { \
         C_MAT feat_mat(pX); \
         HNSW_T *model_ptr = new HNSW_T(); \
-        model_ptr->train(feat_mat, M, efC, max_level, threads); \
+        model_ptr->train(feat_mat, M, efC, threads, max_level_upper_bound); \
         return static_cast<void*>(model_ptr); \
     }
     C_ANN_HNSW_TRAIN(_csr_ip_f32, ScipyCsrF32, pecos::csr_t, hnsw_csr_ip_t)
@@ -430,10 +430,10 @@ extern "C" {
     OMP_PARA_FOR \
         for (uint32_t qid=0; qid < feat_mat.rows; qid++) { \
             int thread_id = omp_get_thread_num(); \
-            auto ret_pairs = searchers[thread_id].predict_single(feat_mat.get_row(qid), efS, topk); \
+            auto& ret_pairs = searchers[thread_id].predict_single(feat_mat.get_row(qid), efS, topk); \
             for (uint32_t k=0; k < ret_pairs.size(); k++) { \
-                ret_val[qid * topk + k] = ret_pairs[k].first; \
-                ret_idx[qid * topk + k] = ret_pairs[k].second; \
+                ret_val[qid * topk + k] = ret_pairs[k].dist; \
+                ret_idx[qid * topk + k] = ret_pairs[k].node_id; \
             } \
         } \
     }

--- a/test/pecos/ann/test_hnsw.py
+++ b/test/pecos/ann/test_hnsw.py
@@ -27,7 +27,7 @@ def test_predict_and_recall():
     random.seed(1234)
     np.random.seed(1234)
     M, efC, top_k = 32, 100, 10
-    max_level, threads = 5, 8
+    max_level_upper_bound, threads = 5, 8
     efS_list = [50, 75, 100]
     num_searcher_online = 2
 
@@ -52,7 +52,14 @@ def test_predict_and_recall():
     Y_true = np.argsort(Y_true)[:, :top_k]
 
     # test dense features
-    model = HNSW.train(X_trn, M, efC, max_level, metric_type, threads)
+    model = HNSW.train(
+        X_trn,
+        M=M,
+        efC=efC,
+        max_level_upper_bound=max_level_upper_bound,
+        metric_type=metric_type,
+        threads=threads,
+    )
     searchers = model.searchers_create(num_searcher_online)
     for efS in efS_list:
         Y_pred, _ = model.predict(X_tst, efS, top_k, searchers=searchers, ret_csr=False)
@@ -65,7 +72,15 @@ def test_predict_and_recall():
     # test csr features, we just reuse the Y_true since data are the same
     X_trn = smat.csr_matrix(X_trn).astype(np.float32)
     X_tst = smat.csr_matrix(X_tst).astype(np.float32)
-    model = HNSW.train(X_trn, M, efC, max_level, metric_type, threads)
+
+    model = HNSW.train(
+        X_trn,
+        M=M,
+        efC=efC,
+        max_level_upper_bound=max_level_upper_bound,
+        metric_type=metric_type,
+        threads=threads,
+    )
     searchers = model.searchers_create(num_searcher_online)
     for efS in efS_list:
         Y_pred, _ = model.predict(X_tst, efS, top_k, searchers=searchers, ret_csr=False)


### PR DESCRIPTION


*Description of changes:*
Refactor HNSW
* reuse priority queues for different inference calls within the same Searcher
* results stored in searcher so no need to allocate every time 
* pre-compute node2level in workspace, so no need pre-specified max_level argument in training 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.