### PR TITLE
Fix vulnerability due to nltk version requirement

### DIFF
--- a/examples/qp2q/README.md
+++ b/examples/qp2q/README.md
@@ -9,6 +9,11 @@ in ["Session-Aware Query-Autocompletion using eXtreme Multi-Label Ranking, KDD 2
 by running the following command:
 ```bash 
 pip install -r requirements.txt  
+
+# NOTE: The original nltk version used in the experiment
+# CAUTION: nltk<=3.6.3 is known to contain an Inefficient Regular Expression and is vulnerable to regular expression denial of service attacks
+# Details: https://github.com/advisories/GHSA-2ww3-fxvq-293j
+pip install nltk==3.4.5
 ```
 If you're unfamiliar with Python virtual environments, check out the 
 [user guide](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/).

--- a/examples/qp2q/README.md
+++ b/examples/qp2q/README.md
@@ -99,3 +99,4 @@ location = {Virtual Event, Singapore},
 series = {KDD '21}
 }
 ```
+

--- a/examples/qp2q/requirements.txt
+++ b/examples/qp2q/requirements.txt
@@ -6,3 +6,4 @@ tqdm==4.42.1
 pygtrie==2.4.2
 pure-predict==0.0.4
 libpecos==0.1.0
+

--- a/examples/qp2q/requirements.txt
+++ b/examples/qp2q/requirements.txt
@@ -3,7 +3,7 @@ scipy==1.4.1
 numpy==1.20.3
 pandas==1.0.1
 tqdm==4.42.1
-nltk==3.4.5
+nltk>=3.6.4
 pygtrie==2.4.2
 pure-predict==0.0.4
 libpecos==0.1.0

--- a/examples/qp2q/requirements.txt
+++ b/examples/qp2q/requirements.txt
@@ -3,7 +3,6 @@ scipy==1.4.1
 numpy==1.20.3
 pandas==1.0.1
 tqdm==4.42.1
-nltk>=3.6.4
 pygtrie==2.4.2
 pure-predict==0.0.4
 libpecos==0.1.0


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Fix vulnerability by upgrading `nltk` version requirement to 3.6.4 or later.

[Details](https://github.com/advisories/GHSA-2ww3-fxvq-293j):

> Vulnerable versions: <= 3.6.3
> Patched version: 3.6.4
> nltk is contains an Inefficient Regular Expression and is vulnerable to regular expression denial of service attacks.
> 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.