### PR TITLE
GitHub CI fail on C/C++ compilation warning to help maintain cleaner code

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install pip
-        make libpecos VFLAG=-v
+        make libpecos VFLAG=-v WARN_AS_ERROR=True
     - name: Test with pytest
       run: |
-        make test VFLAG=-v
+        make test VFLAG=-v WARN_AS_ERROR=True

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,16 @@
 # > make pecos VFLAG=-v
 VFLAG ?=
 
+# C/C++ Compiler warning as error flag, for code cleaning purposes
+# Usage: pass WARN_AS_ERROR=True to command line if need to turn C/C++ warning into error
+# > make libpecos WARN_AS_ERROR=True
+# > make test WARN_AS_ERROR=True
+WARN_AS_ERROR ?=
+ifdef WARN_AS_ERROR
+WARN_AS_ERROR_CMD = PECOS_MANUAL_COMPILE_ARGS="-Werror"
+else
+WARN_AS_ERROR_CMD =
+endif
 
 # Style and type checks
 format: flake8 black mypy
@@ -41,7 +51,7 @@ mypy:
 # Install and unit test
 libpecos:
 	python3 -m pip install --upgrade pip
-	python3 -m pip install ${VFLAG} --editable .
+	${WARN_AS_ERROR_CMD} python3 -m pip install ${VFLAG} --editable .
 
 .PHONY: test
 test: libpecos

--- a/setup.py
+++ b/setup.py
@@ -148,13 +148,23 @@ install_requires = numpy_requires + [
 setuptools.dist.Distribution().fetch_build_eggs(numpy_requires)
 blas_lib, blas_dir = BlasHelper.get_blas_lib_dir()
 
+# Get extra manual compile args if any
+# Example usage:
+# > PECOS_MANUAL_COMPILE_ARGS="-Werror" python3 -m pip install  --editable .
+manual_compile_args = os.environ.get('PECOS_MANUAL_COMPILE_ARGS', default=None)
+if manual_compile_args:
+    manual_compile_args = manual_compile_args.split(',')
+else:
+    manual_compile_args = []
+
+# Compile C/C++ extension
 ext_module = setuptools.Extension(
     "pecos.core.libpecos_float32",
     sources=["pecos/core/libpecos.cpp"],
     include_dirs=["pecos/core", "/usr/include/", "/usr/local/include"],
     libraries=["gomp"] + blas_lib,
     library_dirs=blas_dir,
-    extra_compile_args=["-fopenmp", "-O3", "-std=c++14", "-mavx", "-Werror"],
+    extra_compile_args=["-fopenmp", "-O3", "-std=c++14", "-mavx"] + manual_compile_args,
     extra_link_args=['-Wl,--no-as-needed', f"-Wl,-rpath,{':'.join(blas_dir)}"]
     )
 

--- a/setup.py
+++ b/setup.py
@@ -154,7 +154,7 @@ ext_module = setuptools.Extension(
     include_dirs=["pecos/core", "/usr/include/", "/usr/local/include"],
     libraries=["gomp"] + blas_lib,
     library_dirs=blas_dir,
-    extra_compile_args=["-fopenmp", "-O3", "-std=c++14", "-mavx"],
+    extra_compile_args=["-fopenmp", "-O3", "-std=c++14", "-mavx", "-Werror"],
     extra_link_args=['-Wl,--no-as-needed', f"-Wl,-rpath,{':'.join(blas_dir)}"]
     )
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
In order to maintain cleaner code, we enabled `-Werror` option for **GitHub CI** to help eliminate C/C++ code warning messages (and potential bugs). 

Now pytest CI will automatically fail if C/C++ build has any warning messages. 
Contributors can also check their code locally with `make libpecos WARN_AS_ERROR=True`

Default installation of PECOS will remain the same: C/C++ compiler warnings will **NOT** fail the compilation.

Tested CI on newest code (after commit 88ab474a957fb921a6d8ba93b86658fb12cca506)

- CI Failure (triggered by manually introducing C/C++ warning in the code):
  https://github.com/weiliw-amz/pecos/actions/runs/1330703210
- CI Success: See PR checks


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.