### PR TITLE
XLinear API refactor

### DIFF
--- a/pecos/apps/text2text/README.md
+++ b/pecos/apps/text2text/README.md
@@ -106,25 +106,23 @@ python3 -m pecos.apps.text2text.predict \
 ```
 The predictions are saved in the `./test-prediction.txt`.
 
-### Advanced Usage: Train/Pred params via JSON input
+
+### Advanced Usage: Give parameters via a JSON file
 `pecos.apps.text2text` supports accepting training and predicting parameters from an input JSON file.
 Moreover, `python3 -m pecos.apps.text2text.train` helpfully provide the option to generate all parameters in JSON format to stdout.
 
-You can generate train/pred parameter to `.json` files
-with all of the parameters that you can edit and fill in.
+You can generate a `.json` file with all of the parameters that you can edit and fill in.
 ```bash
-  > python3 -m pecos.apps.text2text.train --generate-train-params-skeleton &> train_params.json
-  > python3 -m pecos.apps.text2text.train --generate-pred-params-skeleton &> pred_params.json
+  > python3 -m pecos.apps.text2text.train --generate-params-skeleton &> params.json
 ```
-After editing the `train_params.json` and `pred_params.json` files, you can do training via:
+After editing the `params.json` file, you can do training via:
 ```bash
   > python3 -m pecos.apps.text2text.train \
 	--input-text-path ./training-data.txt \
 	--vectorizer-config-path ./config.json \
 	--output-item-path ./output-labels.txt \
-	--model-folder ./pecos-text2text-model
-	--train-params-path train_params.json \
-	--pred-params-path pred_params.json
+	--model-folder ./pecos-text2text-model \
+	--params-path params.json
 ```
 ***
 

--- a/pecos/apps/text2text/evaluate.py
+++ b/pecos/apps/text2text/evaluate.py
@@ -54,7 +54,16 @@ def parse_arguments():
         help="Text item file name. Format: each line corresponds to a text item. If this path is given, we assume TRUTH_PATH uses Format 2. Otherwise, TRUTH_PATH uses Format 1",
     )
 
-    parser.add_argument("-k", "--topk", type=int, default=10, metavar="INT", help="evaluate @k")
+    parser.add_argument(
+        "-k",
+        "--topk",
+        "--only-topk",
+        type=int,
+        default=10,
+        dest="topk",
+        metavar="INT",
+        help="evaluate @k",
+    )
 
     return parser
 
@@ -119,7 +128,7 @@ def do_evaluation(args):
     Y_true = smat.csr_matrix((val_t, (row_id_t, col_id_t)), shape=(num_samples_t, len(item_dict)))
     Y_pred = smat.csr_matrix((val_p, (row_id_p, col_id_p)), shape=(num_samples_p, len(item_dict)))
 
-    metric = smat_util.Metrics.generate(Y_true, Y_pred, args.topk)
+    metric = smat_util.Metrics.generate(Y_true, Y_pred, topk=args.topk)
     print("==== evaluation results ====")
     print(metric)
 

--- a/pecos/apps/text2text/model.py
+++ b/pecos/apps/text2text/model.py
@@ -129,7 +129,7 @@ class Text2Text(object):
     def get_pred_params(self):
         """get pred_params saved in the model"""
         ret_pred_params = self.PredParams(
-            xlinear_params=self.xlinear_models.get_pred_params(),
+            xlinear_params=self.xlinear_models[0][0].get_pred_params(),
         )
         return ret_pred_params
 
@@ -367,7 +367,6 @@ class Text2Text(object):
             LOGGER.info(f"Loading existing clustering code with params {indexer_kwargs_dict}")
             C = ClusterChain.load(C_path)
         else:
-            LOGGER.info(f"Clustering with params: {json.dumps(indexer_kwargs_dict, indent=True)}")
             C = Indexer.gen(label_feat, train_params=train_params.indexer_params)
             LOGGER.info("Hierarchical label tree: {}".format([cc.shape[0] for cc in C]))
             C.save(C_path)
@@ -376,12 +375,6 @@ class Text2Text(object):
         gc.collect()
 
         # Ensemble Models
-        LOGGER.info(
-            f"Training model with train params: {json.dumps(train_params.xlinear_params.to_dict(), indent=True)}"
-        )
-        LOGGER.info(
-            f"Training model with pred params: {json.dumps(pred_params.xlinear_params.to_dict(), indent=True)}"
-        )
         m = XLinearModel.train(
             X,
             Y,
@@ -389,7 +382,7 @@ class Text2Text(object):
             R=R,
             train_params=train_params.xlinear_params,
             pred_params=pred_params.xlinear_params,
-            **kwargs,
+            pred_kwargs=kwargs,
         )
 
         xlinear_models = [[m, train_params.to_dict()]]

--- a/pecos/apps/text2text/predict.py
+++ b/pecos/apps/text2text/predict.py
@@ -150,7 +150,7 @@ def predict(args):
                     Y = t2t_model.predict(
                         corpus,
                         beam_size=args.beam_size,
-                        topk=args.only_topk,
+                        only_topk=args.only_topk,
                         threshold=args.threshold,
                     )
                     if args.meta_info_path is None:
@@ -163,7 +163,7 @@ def predict(args):
             if len(corpus) > 0:
                 Y = t2t_model.predict(
                     corpus,
-                    topk=args.only_topk,
+                    only_topk=args.only_topk,
                     beam_size=args.beam_size,
                     post_processor=args.post_processor,
                     threshold=args.threshold,
@@ -177,7 +177,7 @@ def predict(args):
         for line in fin:
             Y = t2t_model.predict(
                 [line.strip()],
-                topk=args.only_topk,
+                only_topk=args.only_topk,
                 beam_size=args.beam_size,
                 post_processor=args.post_processor,
                 threshold=args.threshold,

--- a/pecos/core/base.py
+++ b/pecos/core/base.py
@@ -66,6 +66,7 @@ class TfidfBaseVectorizerParam(ctypes.Structure):
         ("binary", c_bool),
         ("use_idf", c_bool),
         ("smooth_idf", c_bool),
+        ("add_one_idf", c_bool),
         ("sublinear_tf", c_bool),
         ("keep_frequent_feature", c_bool),
         ("norm_p", c_int32),
@@ -84,6 +85,7 @@ class TfidfBaseVectorizerParam(ctypes.Structure):
         "binary": False,
         "use_idf": True,
         "smooth_idf": True,
+        "add_one_idf": False,
         "sublinear_tf": False,
         "keep_frequent_feature": True,
         "norm_p": 2,
@@ -1262,7 +1264,16 @@ class corelib(object):
             self.clib_float32.c_run_clustering_drm_f32, None, [POINTER(ScipyDrmF32)] + arg_list[1:]
         )
 
-    def run_clustering(self, py_feat_mat, depth, algo, seed, codes=None, max_iter=10, threads=-1):
+    def run_clustering(
+        self,
+        py_feat_mat,
+        depth,
+        algo,
+        seed,
+        codes=None,
+        kmeans_max_iter=20,
+        threads=-1,
+    ):
         """
         Run clustering with given label embedding matrix and parameters in C++.
 
@@ -1272,7 +1283,7 @@ class corelib(object):
             algo (str): The algorithm for clustering, either `KMEANS` or `SKMEANS`.
             seed (int): Randoms seed.
             codes (ndarray, optional): Label clustering results.
-            max_iter (int, optional): Maximum number of iter for reordering each node based on score.
+            kmeans_max_iter (int, optional): Maximum number of iter for reordering each node based on score.
             threads (int, optional): The number of threads. Default -1 to use all cores.
 
         Return:
@@ -1296,7 +1307,7 @@ class corelib(object):
             depth,
             algo,
             seed,
-            max_iter,
+            kmeans_max_iter,
             threads,
             codes.ctypes.data_as(POINTER(c_uint32)),
         )
@@ -1404,6 +1415,7 @@ class corelib(object):
                     binary (bool): whether to binarize term frequency, default False
                     use_idf (bool): whether to use inverse document frequency, default True
                     smooth_idf (bool): whether to smooth IDF by adding 1 to all DF counts, default True
+                    add_one_idf (bool): whether to smooth IDF by adding 1 to all IDF scores, default False
                     sublinear_tf (bool): whether to use sublinear mapping (log) on term frequency, default False
                     keep_frequent_feature (bool): if max_feature > 0, will only keep max_feature features by
                                     ignoring features with low document frequency (if True, default),

--- a/pecos/core/utils/tfidf.hpp
+++ b/pecos/core/utils/tfidf.hpp
@@ -81,6 +81,7 @@ extern "C" {
             bool binary,
             bool use_idf,
             bool smooth_idf,
+            bool add_one_idf,
             bool sublinear_tf,
             bool keep_frequent_feature,
             int32_t norm_p,
@@ -96,6 +97,7 @@ extern "C" {
         binary(binary),
         use_idf(use_idf),
         smooth_idf(smooth_idf),
+        add_one_idf(add_one_idf),
         sublinear_tf(sublinear_tf),
         keep_frequent_feature(keep_frequent_feature),
         norm_p(norm_p),
@@ -112,7 +114,7 @@ extern "C" {
         int32_t max_length, max_feature;
         float min_df_ratio, max_df_ratio;
         int32_t min_df_cnt, max_df_cnt;
-        bool binary, use_idf, smooth_idf, sublinear_tf, keep_frequent_feature;
+        bool binary, use_idf, smooth_idf, add_one_idf, sublinear_tf, keep_frequent_feature;
         int32_t norm_p, tok_type;
 
         void save(const string& filepath) const {
@@ -129,6 +131,7 @@ extern "C" {
                     {"binary", binary},
                     {"use_idf", use_idf},
                     {"smooth_idf", smooth_idf},
+                    {"add_one_idf", add_one_idf},
                     {"sublinear_tf", sublinear_tf},
                     {"keep_frequent_feature", keep_frequent_feature},
                     {"norm_p", norm_p == 1 ? "l1" : "l2"}
@@ -181,6 +184,8 @@ extern "C" {
             } else {
                 throw std::invalid_argument("Unknown normalization type");
             }
+	    // handle missing key by filling default value
+            add_one_idf = kwargs.value("add_one_idf", false);
         }
 
     };
@@ -955,7 +960,7 @@ private:
             auto& cur_ptr = ptr_vec[cur_idx + start_idx];
             auto cur_df = final_chunk[cur_ptr->first];
             feature_vocab[cur_ptr->first] = static_cast<idx_type>(cur_idx);
-            idx_idf[cur_idx] = std::max(log(float(nr_doc) / (cur_df + param.smooth_idf)), 0.0);
+            idx_idf[cur_idx] = std::max(log(float(nr_doc) / (cur_df + (size_t)param.smooth_idf)), 0.0) + float(param.add_one_idf);
         }
     }
 

--- a/pecos/utils/cluster_util.py
+++ b/pecos/utils/cluster_util.py
@@ -287,7 +287,7 @@ def hierarchical_kmeans(
     imbalanced_depth=100,
     spherical=True,
     seed=0,
-    max_iter=20,
+    kmeans_max_iter=20,
     threads=-1,
 ):
     """Python implementation of hierarchical 2-means.
@@ -301,7 +301,7 @@ def hierarchical_kmeans(
         imbalanced_depth (int, optional): Maximum depth of imbalanced clustering. After depth `imbalanced_depth` is reached, balanced clustering will be used. Default is `100`.
         spherical (bool, optional): True will l2-normalize the centroids of k-means after each iteration. Default is `True`.
         seed (int, optional): Random seed. Default is `0`.
-        max_iter (int, optional): Maximum number of iterations for each k-means problem. Default is `20`.
+        kmeans_max_iter (int, optional): Maximum number of iterations for each k-means problem. Default is `20`.
         threads (int, optional): Number of threads to use. `-1` denotes all CPUs. Default is `-1`.
 
     Returns:
@@ -310,19 +310,19 @@ def hierarchical_kmeans(
 
     global run_kmeans
 
-    def run_kmeans(cluster, c1, c2, min_size, max_iter, spherical=True):
-        indexer = kmeans(feat_mat_global[cluster], c1, c2, min_size, max_iter, spherical)
+    def run_kmeans(cluster, c1, c2, min_size, kmeans_max_iter, spherical=True):
+        indexer = kmeans(feat_mat_global[cluster], c1, c2, min_size, kmeans_max_iter, spherical)
         return cluster[indexer], cluster[~indexer]
 
     global kmeans
 
-    def kmeans(feat_mat, c1=-1, c2=-1, min_size=50, max_iter=20, spherical=True):
+    def kmeans(feat_mat, c1=-1, c2=-1, min_size=50, kmeans_max_iter=20, spherical=True):
         if c1 == -1:
             c1, c2 = np.random.randint(feat_mat.shape[0]), np.random.randint(1, feat_mat.shape[0])
         c1, c2 = feat_mat[c1], feat_mat[(c1 + c2) % feat_mat.shape[0]]
         old_indexer = np.ones(feat_mat.shape[0]) * -1
 
-        for _ in range(max_iter):
+        for _ in range(kmeans_max_iter):
             scores = np.squeeze(np.asarray(feat_mat.multiply(c1 - c2).sum(1)))
             indexer = scores >= 0
             if indexer.sum() < min_size:
@@ -370,7 +370,7 @@ def hierarchical_kmeans(
                         clusters_big,
                         *map(list, zip(*seeds)),
                         min_sizes,
-                        repeat(max_iter),
+                        repeat(kmeans_max_iter),
                         repeat(spherical),
                     ),
                 )

--- a/pecos/utils/featurization/text/vectorizers.py
+++ b/pecos/utils/featurization/text/vectorizers.py
@@ -127,6 +127,7 @@ class Vectorizer(metaclass=VectorizerMeta):
         """
 
         config = config if config is not None else {"type": "tfidf", "kwargs": {}}
+        LOGGER.debug(f"Train Vectorizer with config: {json.dumps(config, indent=True)}")
         vectorizer_type = config.get("type", None)
         assert (
             vectorizer_type is not None
@@ -245,6 +246,7 @@ class Tfidf(Vectorizer):
                     binary (bool): whether to binarize term frequency, default False
                     use_idf (bool): whether to use inverse document frequency, default True
                     smooth_idf (bool): whether to smooth IDF by adding 1 to all DF counts, default True
+                    add_one_idf (bool): whether to smooth IDF by adding 1 to all IDF scores, default False
                     sublinear_tf (bool): whether to use sublinear mapping (log) on term frequency, default False
                     keep_frequent_feature (bool): if max_feature > 0, will only keep max_feature features by
                                     ignoring features with low document frequency (if True, default),
@@ -276,6 +278,7 @@ class Tfidf(Vectorizer):
             "binary": False,
             "use_idf": True,
             "smooth_idf": True,
+            "add_one_idf": False,
             "sublinear_tf": False,
             "keep_frequent_feature": True,
             "norm": "l2",

--- a/pecos/xmc/xlinear/README.md
+++ b/pecos/xmc/xlinear/README.md
@@ -4,7 +4,7 @@
 It takes sparse or dense numerical vectors as the input and outputs relevant labels for the input vectors.
 
 ## Getting started
-### Command line usage
+### Basic Command line usage
 
 Basic Training and predicting:
 ```bash
@@ -27,6 +27,21 @@ For detailed usage, please refer to
   > python3 -m pecos.xmc.xlinear.train --help
   > python3 -m pecos.xmc.xlinear.predict --help
   > python3 -m pecos.xmc.xlinear.evaluate --help
+```
+
+### Advanced Usage: Give parameters via a JSON file
+`pecos.xmc.xlinear.train` supports accepting training and predicting parameters from an input JSON file.
+Moreover, `python3 -m pecos.xmc.xlinear.train` helpfully provide the option to generate all parameters in JSON format to stdout.
+
+You can generate a `.json` file with all of the parameters that you can edit and fill in.
+```bash
+  > python3 -m pecos.xmc.xlinear.train --generate-params-skeleton &> params.json
+```
+After editing the `params.json` file, you can do training via:
+```bash
+  > python3 -m pecos.xmc.xlinear.train \
+	-x ${X_path} -y ${Y_path} -m ${model_dir} \
+	--params-path params.json
 ```
 
 ### Python Example

--- a/pecos/xmc/xlinear/evaluate.py
+++ b/pecos/xmc/xlinear/evaluate.py
@@ -38,7 +38,16 @@ def parse_arguments():
         help="path to the file of predicted output (CSR: nr_insts * nr_items)",
     )
 
-    parser.add_argument("-k", "--topk", type=int, default=10, metavar="INT", help="evaluate @k")
+    parser.add_argument(
+        "-k",
+        "--topk",
+        "--only-topk",
+        type=int,
+        default=10,
+        dest="topk",
+        metavar="INT",
+        help="evaluate @k",
+    )
 
     return parser
 
@@ -52,7 +61,7 @@ def do_evaluation(args):
 
     Y_true = smat_util.load_matrix(args.truth_path).tocsr()
     Y_pred = smat_util.load_matrix(args.pred_path).tocsr()
-    metric = smat_util.Metrics.generate(Y_true, Y_pred, args.topk)
+    metric = smat_util.Metrics.generate(Y_true, Y_pred, topk=args.topk)
     print("==== evaluation results ====")
     print(metric)
 

--- a/pecos/xmc/xlinear/model.py
+++ b/pecos/xmc/xlinear/model.py
@@ -172,8 +172,8 @@ class XLinearModel(pecos.BaseClass):
             train_params (XLinearModel.TrainParams, optional): instance of XLinearModel.TrainParams
             pred_params (XLinearModel.PredParams, optional): instance of XLinearModel.PredParams
             kwargs:
-                {"beam_size": INT, "only_topk": INT, "post_processor": STR},
-                Default None to use HierarchicalMLModel.PredParams defaults
+                pred_kwargs (dict, optional): prediction kwargs {"beam_size": INT, "only_topk": INT, "post_processor": STR},
+                    Default None to use HierarchicalMLModel.DEFAULT_PRED_KWARGS
 
         Returns:
             XLinearModel: the trained XLinearModel
@@ -194,6 +194,10 @@ class XLinearModel(pecos.BaseClass):
         else:
             pred_params = cls.PredParams.from_dict(pred_params)
         # we don't override pred_params with kwargs["pred_kwargs"] because model depth is unknown!
+        if kwargs.get("pred_kwargs", None) is None:
+            kwargs["pred_kwargs"] = dict()
+            for kw in ["beam_size", "only_topk", "post_processor"]:
+                kwargs["pred_kwargs"][kw] = kwargs.get(kw, None)
 
         if not train_params.min_codes:
             train_params.min_codes = train_params.nr_splits

--- a/pecos/xmc/xtransformer/README.md
+++ b/pecos/xmc/xtransformer/README.md
@@ -42,21 +42,18 @@ For detailed usage, please refer to
   > python3 -m pecos.xmc.xtransformer.encode --help
 ```
 
-### Advanced Usage: Train/Pred params via JSON input
+### Advanced Usage: Give parameters via a JSON file
 `pecos.xmc.xtransformer` supports accepting training and predicting parameters from an input JSON file.
 Moreover, `python3 -m pecos.xmc.xtransformer.train` helpfully provide the option to generate all parameters in JSON format to stdout.
 
-You can generate train/pred parameter to `.json` files
-with all of the parameters that you can edit and fill in.
+You can generate a `.json` file with all of the parameters that you can edit and fill in.
 ```bash
-  > python3 -m pecos.xmc.xtransformer.train --generate-train-params-skeleton &> train_params.json
-  > python3 -m pecos.xmc.xtransformer.train --generate-pred-params-skeleton &> pred_params.json
+  > python3 -m pecos.xmc.xtransformer.train --generate-train-params-skeleton &> params.json
 ```
-After editing the `train_params.json` and `pred_params.json` files, you can do training via:
+After editing the `params.json` file, you can do training via:
 ```bash
   > python3 -m pecos.xmc.xtransformer.train -t ${T_path} -x ${X_path} -y ${Y_path} -m ${model_dir} \
-					--train-params-path train_params.json \
-					--pred-params-path pred_params.json
+	--params-path params.json
 ```
 
 ### Python Example

--- a/pecos/xmc/xtransformer/train.py
+++ b/pecos/xmc/xtransformer/train.py
@@ -31,19 +31,20 @@ def parse_arguments():
     """Parse training arguments"""
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--generate-train-params-skeleton",
+        "--generate-params-skeleton",
         action="store_true",
         help="generate template train-params-json to stdout",
     )
-    parser.add_argument(
-        "--generate-pred-params-skeleton",
-        action="store_true",
-        help="generate template pred-params-json to stdout",
-    )
 
-    gen_train_params = "--generate-train-params-skeleton" in sys.argv
-    gen_pred_params = "--generate-pred-params-skeleton" in sys.argv
-    skip_training = gen_train_params or gen_pred_params
+    skip_training = "--generate-params-skeleton" in sys.argv
+    # ========= parameter jsons ============
+    parser.add_argument(
+        "--params-path",
+        type=str,
+        default=None,
+        metavar="PARAMS_PATH",
+        help="Json file for params (default None)",
+    )
     # ========= train data paths ============
     parser.add_argument(
         "-t",
@@ -101,21 +102,6 @@ def parse_arguments():
         metavar="PATH",
         default="",
         help="path to the file of the test label matrix",
-    )
-    # ========= parameter jsons ============
-    parser.add_argument(
-        "--train-params-path",
-        type=str,
-        default=None,
-        metavar="TRAIN_PARAMS_PATH",
-        help="Json file for train_params (default None)",
-    )
-    parser.add_argument(
-        "--pred-params-path",
-        type=str,
-        default=None,
-        metavar="PRED_PARAMS_PATH",
-        help="Json file for pred_params (default None)",
     )
     # ========= indexer parameters ============
     parser.add_argument(
@@ -242,6 +228,7 @@ def parse_arguments():
         type=str,
         choices=["tfn", "man", "tfn+man"],
         default="tfn",
+        dest="neg_mining_chain",
         metavar="STR",
         help="Negative Sampling Schemes",
     )
@@ -470,31 +457,30 @@ def do_train(args):
     Args:
         args (argparse.Namespace): Command line arguments parsed by `parser.parse_args()`
     """
-    if args.generate_train_params_skeleton:
-        train_params = XTransformer.TrainParams.from_dict({}, recursive=True)
-        print(f"{json.dumps(train_params.to_dict(), indent=True)}")
+    params = dict()
+    if args.generate_params_skeleton:
+        params["train_params"] = XTransformer.TrainParams.from_dict({}, recursive=True).to_dict()
+        params["pred_params"] = XTransformer.PredParams.from_dict({}, recursive=True).to_dict()
+        print(f"{json.dumps(params, indent=True)}")
         return
 
-    if args.generate_pred_params_skeleton:
-        pred_params = XTransformer.PredParams.from_dict({}, recursive=True)
-        print(f"{json.dumps(pred_params.to_dict(), indent=True)}")
-        return
+    if args.params_path:
+        with open(args.params_path, "r") as fin:
+            params = json.load(fin)
 
-    # for HierarchicalMLModel.TrainParams
-    args.neg_mining_chain = args.negative_sampling
+    train_params = params.get("train_params", None)
+    pred_params = params.get("pred_params", None)
 
-    if args.train_params_path:
-        with open(args.train_params_path, "r") as fin:
-            train_params = XTransformer.TrainParams.from_dict(json.load(fin))
+    if train_params is not None:
+        train_params = XTransformer.TrainParams.from_dict(train_params)
     else:
         train_params = XTransformer.TrainParams.from_dict(
             {k: v for k, v in vars(args).items() if v is not None},
             recursive=True,
         )
 
-    if args.pred_params_path:
-        with open(args.pred_params_path, "r") as fin:
-            pred_params = XTransformer.PredParams.from_dict(json.load(fin))
+    if pred_params is not None:
+        pred_params = XTransformer.PredParams.from_dict(pred_params)
     else:
         pred_params = XTransformer.PredParams.from_dict(
             {k: v for k, v in vars(args).items() if v is not None},

--- a/test/pecos/utils/test_smat_utils.py
+++ b/test/pecos/utils/test_smat_utils.py
@@ -209,3 +209,39 @@ def test_get_row_submatrices():
     assert X0_sub == approx(Xres)
     assert type(X1_sub) == type(X1)
     assert X1_sub.todense() == approx(Xres)
+
+
+def test_csr_ensembler():
+    from pecos.utils import smat_util
+    from scipy import sparse as smat
+    import numpy as np
+
+    X0 = np.array([[0.5, 0, 0, 1.0], [0, 0.2, 0, 0.5]])
+    X1 = np.array([[1.0, 0, 0, 0.2], [0, 0, 0.2, 0]])
+    X0 = smat_util.sorted_csr(smat.csr_matrix(X0))
+    X1 = smat_util.sorted_csr(smat.csr_matrix(X1))
+
+    # average
+    X_avr = np.array([[0.75, 0, 0, 0.6], [0, 0.1, 0.1, 0.25]])
+    X_avr_pred = smat_util.CsrEnsembler.average(X0, X1).todense()
+    assert X_avr_pred == approx(X_avr), X_avr_pred
+
+    # rank_average
+    X_rank = np.array([[1.5, 0, 0, 1.5], [0, 0.5, 1, 1]])
+    X_rank_pred = smat_util.CsrEnsembler.rank_average(X0, X1).todense()
+    assert X_rank_pred == approx(X_rank), X_rank_pred
+
+    # sigmoid_average
+    X_sig = np.array([[0.67675895, 0.0, 0.0, 0.64044629], [0.0, 0.274917, 0.274917, 0.31122967]])
+    X_sig_pred = smat_util.CsrEnsembler.sigmoid_average(X0, X1).todense()
+    assert X_sig_pred == approx(X_sig), X_sig_pred
+
+    # softmax_average
+    X_soft = np.array([[0.5090297, 0, 0, 0.4909703], [0, 0.24092582, 0.5, 0.25907418]])
+    X_soft_pred = smat_util.CsrEnsembler.softmax_average(X0, X1).todense()
+    assert X_soft_pred == approx(X_soft), X_soft_pred
+
+    # round_robin
+    X_rr = np.array([[1.16666667, 0, 0, 1.33333333], [0, 0.83333333, 1.16666667, 1.33333333]])
+    X_rr_pred = smat_util.CsrEnsembler.round_robin(X0, X1).todense()
+    assert X_rr_pred == approx(X_rr), X_rr_pred


### PR DESCRIPTION
*Description of changes:*
* refactor `pecos.xmc.xlinear.train` API to take JSON inputs
* Add function to generate `train_param`, `pred_param` and `indexer_param` skeletons.
* Add new argument for TFIDF to smooth IDF scores by adding 1.0 to all IDFs.
* Add debug logger to output train/pred params during training for `XLinearModel`, `HierarchicalKMeans` and `Vectorizer`
* Rename the `max_iter` argument for `HierarchicalKMeans` to `max_kmeans_iter` to avoid conflict with `max_iter` under `MLModel`. This also affects the CLI argument for `pecos.xmc.xlinear.train` and `pecos.apps.text2text.train`.
* Add new ensemble methods: `CsrEnsembler.sigmoid_average` and `CsrEnsembler.softmax_average`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.