### PR TITLE
Remove NumPy BLAS Lib Dependency for PECOS installation

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -22,7 +22,11 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
+        sudo apt-get update && sudo apt-get install -y libopenblas-dev
         python -m pip install pip
+        python -m pip install --upgrade pip
+    - name: Install PECOS
+      run: |
         make libpecos VFLAG=-v WARN_AS_ERROR=True
     - name: Test with pytest
       run: |

--- a/setup.py
+++ b/setup.py
@@ -82,43 +82,21 @@ __version__ = "%s"
 
 
 class BlasHelper(object):
-    """Helper class to figure out BLAS library with path from user's Numpy backend libraries."""
-
-    @classmethod
-    def __get_numpy_openblas_lib(cls):
-        """Return NumPy's backend OpenBLAS lib if installed from pip wheel"""
-        import numpy
-        if numpy.distutils.system_info.get_info('openblas'):
-            # System has OpenBLAS, no need to get NumPy's copy
-            return ""
-
-        np_lib_path = os.path.dirname(numpy.__file__) + '.libs'
-
-        for lib_file in os.listdir(np_lib_path):
-            if lib_file.startswith("libopenblas"):
-                lib_path = os.path.join(np_lib_path, lib_file)
-                print(f"NumPy's backend OpenBLAS lib is: {lib_path}")
-                return lib_path
-        else: # Not Found
-            print("NumPy's backend OpenBLAS lib is not found")
-            return ""
+    """Helper class to figure out user's BLAS library path by Numpy's system-info tool."""
 
     @classmethod
     def get_blas_lib_dir(cls):
-        """Return user's NumPy backend BLAS library. If not found, will raise error."""
+        """Return user's BLAS library found by Numpy's system-info tool. If not found, will raise error."""
         import numpy.distutils.system_info as nps
 
-        # Add NumPy's backend openblas lib into search scope
-        os.environ["LAPACK"] = cls.__get_numpy_openblas_lib()
-
         blas_info = nps.get_info('lapack_opt')
-        assert blas_info, "NumPy backend BLAS/LAPACK library not found, need to re-install NumPy"
+        assert blas_info, "No BLAS/LAPACK library is found, need to install BLAS."
 
         blas_lib = blas_info['libraries']
         blas_dir = blas_info['library_dirs']
 
-        assert blas_lib, "NumPy backend BLAS/LAPACK library empty, need to re-install NumPy."
-        assert blas_dir, "NumPy backend BLAS/LAPACK library directory empty, need to re-install NumPy."
+        assert blas_lib, "No BLAS/LAPACK library is found, need to install BLAS."
+        assert blas_dir, "No BLAS/LAPACK library directory is found, need to install BLAS."
 
         return blas_lib, blas_dir
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Previous PECOS installation would link against Numpy's hidden back-end BLAS library, if no BLAS library is found in user's installation environment.
However, this is not considered to be a safe practice. Instead, letting user install and use a separate BLAS lib on their own would be better. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.