### PR TITLE
fix cost-sensitive bug in R normalization

### DIFF
--- a/pecos/utils/cluster_util.py
+++ b/pecos/utils/cluster_util.py
@@ -275,7 +275,10 @@ class ClusterChain(object):
         relevance_chain.reverse()
 
         if norm_type not in [None, "no-norm"]:
-            relevance_chain = [sk_normalize(rr.tocsr(), norm=norm_type) for rr in relevance_chain]
+            relevance_chain = [
+                sk_normalize(rr.tocsr(), norm=norm_type) if rr is not None else None
+                for rr in relevance_chain
+            ]
 
         return relevance_chain[1:]
 

--- a/test/pecos/utils/test_cluster_util.py
+++ b/test/pecos/utils/test_cluster_util.py
@@ -73,6 +73,12 @@ def test_cluster_chain(tmpdir):
     relevance_chain = chain_orig.generate_relevance_chain({0: R, 2: R2, 3: None}, norm_type="l1")
     for pred, res in zip(relevance_chain, [R0_res, R1_res, R2_res]):
         assert pred.toarray() == approx(res)
+    relevance_chain = chain_orig.generate_relevance_chain({0: R}, norm_type="l1", induce=False)
+    for pred, res in zip(relevance_chain, [None, None, R2_res]):
+        if res is None:
+            assert pred is None
+        else:
+            assert pred.toarray() == approx(res)
 
 
 def test_hierarchical_kmeans():


### PR DESCRIPTION
*Description of changes:*
fix cost-sensitive bug in R normalization when `rel_mode` is `ranker-only`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.