### PR TITLE
properly set Text2Text prediction argument

### DIFF
--- a/pecos/apps/text2text/predict.py
+++ b/pecos/apps/text2text/predict.py
@@ -61,8 +61,9 @@ def parse_arguments():
         "-k",
         "--only-topk",
         type=int,
-        default=20,
-        help="Output top-k items for each input (default 20)",
+        default=None,
+        metavar="INT",
+        help="override the only topk specified in the model (default None to disable overriding)",
     )
 
     parser.add_argument(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Set `only_topk` of `text2text.predict` to `None` as the default

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.