### PR TITLE
Modify supported Python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Given an input, PECOS identifies a small set (10-100) of relevant outputs from a
 
 ## Requirements and Installation
 
-* Python (>=3.6)
+* Python (>=3.6, <=3.9)
 * Pip (>=19.3)
 
 See other dependencies in [`setup.py`](https://github.com/amzn/pecos/blob/mainline/setup.py#L135)


### PR DESCRIPTION
*Issue #, if available:*
#112 

*Description of changes:*
As in the #112 PyTorch (one of PECOS dependency) is not ready for Python3.10, PECOS is restricted to Python >=3.6, <=3.9 for now, and will update once PECOS dependencies are ready for Python3.10

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.