### PR TITLE
Fix FMV setup link flag and add test wheel CI

### DIFF
--- a/.github/workflows/build_pypi.yml
+++ b/.github/workflows/build_pypi.yml
@@ -17,6 +17,11 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v1
       with:
@@ -33,6 +38,18 @@ jobs:
         --env PLAT=${{ matrix.build_platform }} --env PIP_VER=${{ matrix.python-version }} \
         --env DOCKER_MNT=$DOCKER_MNT --env WHEEL_DIR=$WHEEL_DIR \
         $DOCKER_IMG /bin/bash /$DOCKER_MNT/.github/build_pypi_wheel.sh
+
+    - name: Test Wheel
+      if: matrix.build_platform == 'manylinux2014_x86_64' # Only test for x86, aarch64 simulation too slow
+      env:
+        WHEEL_DIR: wheel # wheel location
+      run: |
+        python3 -m pip install $WHEEL_DIR/$(ls $WHEEL_DIR)
+        mkdir wheel_test
+        cp -r test/ wheel_test/
+        cd wheel_test
+        python3 -m pip install pytest pytest-coverage
+        python3 -m pytest
 
     - name: Check Version Tag
       id: check-ver-tag

--- a/setup.py
+++ b/setup.py
@@ -140,7 +140,7 @@ ext_module = setuptools.Extension(
     "pecos.core.libpecos_float32",
     sources=["pecos/core/libpecos.cpp"],
     include_dirs=["pecos/core", "/usr/include/", "/usr/local/include"],
-    libraries=["gomp"] + blas_lib,
+    libraries=["gomp", "gcc"] + blas_lib,
     library_dirs=blas_dir,
     extra_compile_args=["-fopenmp", "-O3", "-std=c++14"] + manual_compile_args,
     extra_link_args=['-Wl,--no-as-needed', f"-Wl,-rpath,{':'.join(blas_dir)}"]


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
The introduction of function multi-versioning for SIMD functions requires explicitly linking of gcc libraries for lower version GCC on some platforms and manylinux docker images for building wheels.

Also, added test to install compiled wheels and run unittests for `x86_64` to test against any runtime errors.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.