### PR TITLE
Improve XR-Transformer memory efficiency

### DIFF
--- a/pecos/xmc/xtransformer/module.py
+++ b/pecos/xmc/xtransformer/module.py
@@ -8,9 +8,15 @@
 #  or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
 #  OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
 #  and limitations under the License.
+import logging
 import numpy as np
+import torch
 import scipy.sparse as smat
+from pecos.utils import smat_util
 from torch.utils.data import Dataset, TensorDataset
+from transformers import BatchEncoding
+
+LOGGER = logging.getLogger(__name__)
 
 
 class MLProblemWithText(object):
@@ -39,7 +45,7 @@ class MLProblemWithText(object):
 
     @property
     def is_tokenized(self):
-        return isinstance(self.X_text, dict)
+        return isinstance(self.X_text, (dict, BatchEncoding))
 
     def type_check(self):
         if self.X_feat is not None and not isinstance(self.X_feat, (smat.csr_matrix, np.ndarray)):
@@ -63,8 +69,12 @@ class MLProblemWithText(object):
     def nr_codes(self):
         return None if self.C is None else self.C.shape[1]
 
+    @property
+    def nr_inst(self):
+        return self.Y.shape[0]
 
-class XMCDataset(Dataset):
+
+class XMCTensorDataset(Dataset):
     """Dataset to hold feature and label tensors for XMC training and prediction.
 
     Args:
@@ -95,6 +105,13 @@ class XMCDataset(Dataset):
         self.label_values = label_values
         self.label_indices = label_indices
 
+    @property
+    def num_active_labels(self):
+        if self.label_indices is None:
+            return None
+        else:
+            return self.label_indices.shape[1]
+
     def __getitem__(self, index):
         if self.label_values is not None and self.label_indices is not None:
             return self.data[index] + (self.label_values[index], self.label_indices[index])
@@ -112,3 +129,132 @@ class XMCDataset(Dataset):
         """Refresh label-values and label-indices from given tensors"""
         self.label_values = label_values
         self.label_indices = label_indices
+
+
+class XMCTextDataset(Dataset):
+    """Dataset to hold text and label/matching matrices for XMC training and prediction.
+        Conduct real-time tokenization of input text and label tensor generation to save memory.
+
+    Args:
+        text (list of str): input text, length = nr_inst
+        input_transform (function): the transform function to process/tokenize text
+        feature_keys (list of str): the feature keys in order for batch generation.
+        Y (csr_matrix, optional): training labels, shape = (nr_inst, nr_labels)
+        M (csr_matrix, optional): matching matrix, shape = (nr_inst, nr_codes)
+            model will be trained only on its non-zero indices
+            its values will not be used.
+        idx_padding (int, optional): the index used to pad all label_indices
+            to the same length. Default -1
+        max_labels (int, optional): max number of labels considered for each
+            instance, will subsample from existing label indices if need to.
+            Default None to ignore.
+
+
+    Return values depend on the Y and M:
+        1. Both Y and M are not None (train on middle layer):
+            data[i] = (feature[0][i], feature[1][i], ..., label_values[i], label_indices[i])
+        2. Both Y and M are None (inference on top layer):
+            data[i] = (feature[0][i], feature[1][i], ...)
+        2. Y is not None, M is None (train on top layer):
+            data[i] = (feature[0][i], feature[1][i], ..., label_values[i])
+        3. Y is None, M is not None (inference on middle layer):
+            data[i] = (feature[0][i], feature[1][i], ..., label_indices[i])
+    """
+
+    def __init__(
+        self,
+        text,
+        input_transform,
+        feature_keys,
+        Y=None,
+        M=None,
+        idx_padding=-1,
+        max_labels=None,
+    ):
+        self.text = text
+        self.input_transform = input_transform
+        self.feature_keys = feature_keys
+        self.idx_padding = idx_padding
+
+        self.lbl_mat = None
+        self.has_label = Y is not None
+        self.has_ns = M is not None
+
+        self.offset = 0
+
+        if M is None and Y is None:
+            # 1.inference at top layer
+            self.label_width = None
+        elif M is not None and Y is None:
+            # 2.inference at intermediate layer
+            self.label_width = max(M.indptr[1:] - M.indptr[:-1])
+            self.lbl_mat = smat_util.binarized(M)
+        elif M is None and Y is not None:
+            # 3.train at top layer
+            self.label_width = Y.shape[1]
+            self.lbl_mat = Y.astype(np.float32)
+        elif M is not None and Y is not None:
+            # 4.train at intermediate layer
+            self.lbl_mat = smat_util.binarized(M) + smat_util.binarized(Y)
+            self.label_width = max(self.lbl_mat.indptr[1:] - self.lbl_mat.indptr[:-1])
+            # put values in M, positive labels equal to y + offset, negative to offset
+            # offset is used to avoid elimination of zero entrees
+            self.offset = Y.data.max() + 10.0
+            self.lbl_mat.data[:] = self.offset
+            self.lbl_mat += Y
+
+        if self.label_width is not None and max_labels is not None:
+            if self.label_width > max_labels:
+                LOGGER.warning(f"will need to sub-sample from {self.label_width} to {max_labels}")
+                self.label_width = max_labels
+
+        if Y is not None:
+            label_lower_bound = max(Y.indptr[1:] - Y.indptr[:-1])
+            if label_lower_bound > self.label_width:
+                LOGGER.warning(
+                    f"label-width ({self.label_width}) is not able to cover all positive labels ({label_lower_bound})!"
+                )
+
+    def __len__(self):
+        return len(self.text)
+
+    @property
+    def num_active_labels(self):
+        return self.label_width
+
+    def get_input_tensors(self, i):
+        ret = self.input_transform(self.text[i])
+        ret["instance_number"] = torch.IntTensor([i])
+        return tuple(ret[kk].squeeze(dim=0) for kk in self.feature_keys)
+
+    def get_output_tensors(self, i):
+        if not self.has_ns:
+            if not self.has_label:
+                return tuple()
+            else:
+                return (torch.FloatTensor(self.lbl_mat[i].toarray()).squeeze(dim=0),)
+        else:
+            nr_active = self.lbl_mat.indptr[i + 1] - self.lbl_mat.indptr[i]
+            rng = slice(self.lbl_mat.indptr[i], self.lbl_mat.indptr[i + 1])
+
+            if nr_active > self.label_width:
+                # sub-sample to fit in self.label_width
+                nr_active = self.label_width
+                rng = np.random.choice(
+                    np.arange(self.lbl_mat.indptr[i], self.lbl_mat.indptr[i + 1]),
+                    nr_active,
+                    replace=False,
+                )
+
+            label_indices = torch.zeros((self.label_width,), dtype=torch.int) + self.idx_padding
+            label_indices[:nr_active] = torch.from_numpy(self.lbl_mat.indices[rng])
+
+            if not self.has_label:
+                return (label_indices,)
+            else:
+                label_values = torch.zeros((self.label_width,), dtype=torch.float32)
+                label_values[:nr_active] = torch.from_numpy(self.lbl_mat.data[rng] - self.offset)
+                return (label_values, label_indices)
+
+    def __getitem__(self, index):
+        return self.get_input_tensors(index) + self.get_output_tensors(index)

--- a/pecos/xmc/xtransformer/network.py
+++ b/pecos/xmc/xtransformer/network.py
@@ -38,6 +38,7 @@ from transformers.modeling_utils import SequenceSummary
 
 from transformers.models.bert.modeling_bert import BERT_INPUTS_DOCSTRING, BERT_START_DOCSTRING
 from transformers.models.roberta.modeling_roberta import (
+    RobertaPreTrainedModel,
     ROBERTA_INPUTS_DOCSTRING,
     ROBERTA_START_DOCSTRING,
 )
@@ -269,7 +270,7 @@ class BertForXMC(BertPreTrainedModel):
     """Roberta Model with mutli-label classification head on top for XMC.\n""",
     ROBERTA_START_DOCSTRING,
 )
-class RobertaForXMC(BertPreTrainedModel):
+class RobertaForXMC(RobertaPreTrainedModel):
     """
     Examples:
         tokenizer = RobertaTokenizer.from_pretrained('roberta-base')

--- a/test/pecos/xmc/xtransformer/test_xtransformer.py
+++ b/test/pecos/xmc/xtransformer/test_xtransformer.py
@@ -148,7 +148,6 @@ def test_encode(tmpdir):
 
     model_folder = tmpdir.join("only_encoder")
     emb_path = model_folder.join("embeddings.npy")
-    save_emb_path = model_folder.join("X.trn.npy")
     emb_path_B1 = model_folder.join("embeddings_B1.npy")
 
     # Training matcher
@@ -164,7 +163,6 @@ def test_encode(tmpdir):
     cmd += ["--save-steps {}".format(2)]
     cmd += ["--only-topk {}".format(2)]
     cmd += ["--batch-gen-workers {}".format(2)]
-    cmd += ["--save-emb-dir {}".format(str(model_folder))]
     cmd += ["--only-encoder true"]
     process = subprocess.run(
         shlex.split(" ".join(cmd)), stdout=subprocess.PIPE, stderr=subprocess.PIPE
@@ -184,9 +182,7 @@ def test_encode(tmpdir):
     )
     assert process.returncode == 0, " ".join(cmd)
 
-    X_emb_save = np.load(str(save_emb_path))
     X_emb_pred = np.load(str(emb_path))
-    assert X_emb_pred == approx(X_emb_save, abs=1e-6)
 
     # encode with max_pred_chunk=1
     cmd = []
@@ -203,7 +199,7 @@ def test_encode(tmpdir):
     assert process.returncode == 0, " ".join(cmd)
 
     X_emb_pred_B1 = np.load(str(emb_path_B1))
-    assert X_emb_pred_B1 == approx(X_emb_save, abs=1e-6)
+    assert X_emb_pred_B1 == approx(X_emb_pred, abs=1e-6)
 
 
 def test_xtransformer_python_api():


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Add `XMCTextDataset`, a dataset for XMC problem that tokenizes input text at batch generation time. This avoids pre-tokenizing the whole training corpus which could lead to OOM when number of instances is big.
* Deprecated `--save-emb-dir` argument in `pecos.xmc.xtransformer.train`. Embeddings should be obtained through `pecos.xmc.xtransformer.encode`.
* Deprecated `--steps-scale` argument in `pecos.xmc.xtransformer.train`. Setting different training steps for each layer should be done through setting custom `max_steps` in the `TransformerMatcher.TrainParams`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.