### PR TITLE
Fix only-topk issue in smat_util.sorted_csc

### DIFF
--- a/pecos/utils/smat_util.py
+++ b/pecos/utils/smat_util.py
@@ -222,7 +222,7 @@ def sorted_csc_from_coo(shape, row_idx, col_idx, val, only_topk=None):
     Returns:
         csc_matrix
     """
-    csr = sorted_csr_from_coo(shape[::-1], col_idx, row_idx, val, only_topk=None)
+    csr = sorted_csr_from_coo(shape[::-1], col_idx, row_idx, val, only_topk=only_topk)
     return transpose(csr)
 
 
@@ -287,7 +287,7 @@ def sorted_csc(csc, only_topk=None):
     if not isinstance(csc, smat.csc_matrix):
         raise ValueError("the input matrix must be a csc_matrix.")
 
-    return transpose(sorted_csr(transpose(csc)))
+    return transpose(sorted_csr(transpose(csc), only_topk=only_topk))
 
 
 def dense_to_csr(dense, topk=None, batch=None):


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* Fix the issue in `smat_util.sorted_csc` and `smat_util.sorted_csc_from_coo` that keyword argument `only_topk` is not working.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.