### PR TITLE
fix indptr overflow issue in block_diag_csr()

### DIFF
--- a/pecos/utils/smat_util.py
+++ b/pecos/utils/smat_util.py
@@ -477,7 +477,9 @@ def block_diag_csr(matrices, dtype=None):
     for mat in matrices:
         data[cur_nnz : cur_nnz + mat.nnz] = mat.data
         indices[cur_nnz : cur_nnz + mat.nnz] = mat.indices + cur_col
-        indptr[1 + cur_row : 1 + cur_row + mat.shape[0]] = mat.indptr[1:] + indptr[cur_row]
+        indptr[1 + cur_row : 1 + cur_row + mat.shape[0]] = (
+            mat.indptr[1:].astype(indptr.dtype) + indptr[cur_row]
+        )
         cur_col += mat.shape[1]
         cur_row += mat.shape[0]
         cur_nnz += mat.nnz


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
fix indptr overflow issue in `smat_util.block_diag_csr()` function by up-casting `indptr.dtype` of input matrices.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.