### PR TITLE
Avoid triggering codeql on push for Dependabot branches

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,6 +2,7 @@ name: "CodeQL Scanning"
 
 on:
   push:
+    branches-ignore: "dependabot/**"
   pull_request:
   schedule:
     - cron: '0 19 * * 0'


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Ignore Depandabot for codeql check on push

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.