### PR TITLE
Deprecate imbalanced hierarchical K-means from clustering and semantic indexing.

### DIFF
--- a/examples/pecos-xrlinear-jmlr22/xrl_train.py
+++ b/examples/pecos-xrlinear-jmlr22/xrl_train.py
@@ -113,22 +113,6 @@ def parse_arguments():
     )
 
     parser.add_argument(
-        "--imbalanced-ratio",
-        type=float,
-        default=0.0,
-        metavar="FLOAT",
-        help="Value between 0.0 and 0.5 (inclusive). Indicates how relaxed the balancedness constraint of 2-means can be. Specifically, if an iteration of 2-means is clustering L labels, the size of the output 2 clusters will be within approx imbalanced_ratio * 2 * L of each other. (default 0.0)",
-    )
-
-    parser.add_argument(
-        "--imbalanced-depth",
-        type=int,
-        default=100,
-        metavar="INT",
-        help="After hierarchical 2-means clustering has reached this depth, it will continue clustering as if --imbalanced-ratio is set to 0.0. (default 100)",
-    )
-
-    parser.add_argument(
         "--spherical",
         type=cli.str2bool,
         metavar="[true/false]",

--- a/pecos/apps/text2text/train.py
+++ b/pecos/apps/text2text/train.py
@@ -114,22 +114,6 @@ def parse_arguments(args):
     )
 
     parser.add_argument(
-        "--imbalanced-ratio",
-        type=float,
-        default=0.0,
-        metavar="FLOAT",
-        help="Value between 0.0 and 0.5 (inclusive). Indicates how relaxed the balancedness constraint of 2-means can be. Specifically, if an iteration of 2-means is clustering L labels, the size of the output 2 clusters will be within approx imbalanced_ratio * 2 * L of each other. (default 0.0)",
-    )
-
-    parser.add_argument(
-        "--imbalanced-depth",
-        type=int,
-        default=100,
-        metavar="INT",
-        help="After hierarchical 2-means clustering has reached this depth, it will continue clustering as if --imbalanced-ratio is set to 0.0. (default 100)",
-    )
-
-    parser.add_argument(
         "--label-embed-type",
         type=str,
         default="pifa",

--- a/pecos/xmc/xlinear/train.py
+++ b/pecos/xmc/xlinear/train.py
@@ -103,22 +103,6 @@ def parse_arguments():
     )
 
     parser.add_argument(
-        "--imbalanced-ratio",
-        type=float,
-        default=0.0,
-        metavar="FLOAT",
-        help="Value between 0.0 and 0.5 (inclusive). Indicates how relaxed the balancedness constraint of 2-means can be. Specifically, if an iteration of 2-means is clustering L labels, the size of the output 2 clusters will be within approx imbalanced_ratio * 2 * L of each other. (default 0.0)",
-    )
-
-    parser.add_argument(
-        "--imbalanced-depth",
-        type=int,
-        default=100,
-        metavar="INT",
-        help="After hierarchical 2-means clustering has reached this depth, it will continue clustering as if --imbalanced-ratio is set to 0.0. (default 100)",
-    )
-
-    parser.add_argument(
         "--spherical",
         type=cli.str2bool,
         metavar="[true/false]",

--- a/pecos/xmc/xtransformer/train.py
+++ b/pecos/xmc/xtransformer/train.py
@@ -147,20 +147,6 @@ def parse_arguments():
         metavar="INT",
         help="The max size of the leaf nodes of hierarchical clustering. If larger than the number of labels, OVA model will be trained. Default 100.",
     )
-    parser.add_argument(
-        "--imbalanced-ratio",
-        type=float,
-        default=0.0,
-        metavar="FLOAT",
-        help="Value between 0.0 and 0.5 (inclusive). Indicates how relaxed the balancedness constraint of 2-means can be. Specifically, if an iteration of 2-means is clustering L labels, the size of the output 2 clusters will be within approx imbalanced_ratio * 2 * L of each other. (default 0.0)",
-    )
-    parser.add_argument(
-        "--imbalanced-depth",
-        type=int,
-        default=100,
-        metavar="INT",
-        help="After hierarchical 2-means clustering has reached this depth, it will continue clustering as if --imbalanced-ratio is set to 0.0. (default 100)",
-    )
     # ========= matcher parameters ============
     parser.add_argument(
         "--max-match-clusters",

--- a/test/pecos/xmc/test_xmc.py
+++ b/test/pecos/xmc/test_xmc.py
@@ -38,12 +38,6 @@ def test_hierarchicalkmeans():
         ~balanced_assignments, target_balanced
     )
 
-    imbalanced_chain = Indexer.gen(feat_mat, imbalanced_ratio=0.4, max_leaf_size=3)
-    imbalanced_assignments = (imbalanced_chain[-1].todense() == [0, 1]).all(axis=1).A1
-    assert np.array_equal(imbalanced_assignments, target_imbalanced) or np.array_equal(
-        ~imbalanced_assignments, target_imbalanced
-    )
-
     chain2 = Indexer.gen(feat_mat, max_leaf_size=1, nr_splits=2)
     chain4 = Indexer.gen(feat_mat, max_leaf_size=1, nr_splits=4)
 

--- a/test/pecos/xmc/test_xmc.py
+++ b/test/pecos/xmc/test_xmc.py
@@ -30,7 +30,6 @@ def test_hierarchicalkmeans():
         smat.csr_matrix([[1, 0], [0.95, 0.05], [0.9, 0.1], [0, 1]], dtype=np.float32)
     )
     target_balanced = [0, 0, 1, 1]
-    target_imbalanced = [0, 0, 0, 1]
 
     balanced_chain = Indexer.gen(feat_mat, max_leaf_size=3)
     balanced_assignments = (balanced_chain[-1].todense() == [0, 1]).all(axis=1).A1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Deprecate imbalanced hierarchical K-means from clustering and semantic indexing. The Python-implemented hierarchical 2-means with imbalanced functions still remains in pecos/utils/cluster_util.py.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.