### PR TITLE
cluster chain loading to support for both file and dir

### DIFF
--- a/pecos/xmc/xtransformer/train.py
+++ b/pecos/xmc/xtransformer/train.py
@@ -511,11 +511,7 @@ def do_train(args):
 
     # load cluster chain
     if os.path.exists(args.code_path):
-        cluster_chain = ClusterChain.from_partial_chain(
-            smat_util.load_matrix(args.code_path),
-            min_codes=args.min_codes,
-            nr_splits=args.nr_splits,
-        )
+        cluster_chain = ClusterChain.load(args.code_path)
         LOGGER.info("Loaded from code-path: {}".format(args.code_path))
     else:
         if os.path.isfile(args.label_feat_path):


### PR DESCRIPTION
*Issue #, if available:*
ClusterChain loading code in xtransformer/train.py is differ from the same code in xlinear/train.py and this causes a problem when reading custom code from a directory.

*Description of changes:*
XTransformer requires file path CSR matrix) as code-path, not a directory that contains .npz files and a config file. In fact, CluasterChain can handle both directory path and single file path as input. In XLinear, cluster input is assumed as a directory. This inconsistency could cause confusions in using the library. This PR changes cluster loading code in XTransformer as the same in XLinear to resolve the issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.