### PR TITLE
Fix Pypi release version error

### DIFF
--- a/.github/build_pypi_wheel.sh
+++ b/.github/build_pypi_wheel.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+# Git requires repository folder to be owned and accessed by the same user, or add the folder to safe directory
+# Otherwise, git commands cannot be successfully executed and thus correct PECOS version could not be retrieved
+# See: https://github.blog/2022-04-12-git-security-vulnerability-announced/
+git config --global --add safe.directory $DOCKER_MNT
+
 # Get pip
 echo "Build wheel using Python version $PIP_VER..."
 PIP=$(ls /opt/python/cp${PIP_VER//./}-cp*/bin/pip)

--- a/.github/build_pypi_wheel.sh
+++ b/.github/build_pypi_wheel.sh
@@ -4,7 +4,9 @@ set -e
 # Git requires repository folder to be owned and accessed by the same user, or add the folder to safe directory
 # Otherwise, git commands cannot be successfully executed and thus correct PECOS version could not be retrieved
 # See: https://github.blog/2022-04-12-git-security-vulnerability-announced/
-git config --global --add safe.directory $DOCKER_MNT
+git config --global --add safe.directory /$DOCKER_MNT
+PECOS_TAG=$(cd $DOCKER_MNT && git describe  --tags --abbrev=0)
+echo "Building wheel for PECOS $PECOS_TAG..."
 
 # Get pip
 echo "Build wheel using Python version $PIP_VER..."


### PR DESCRIPTION
Due to recent Git security feature: https://github.blog/2022-04-12-git-security-vulnerability-announced/, Git requires repository folder to be owned and accessed by the same user, or add the folder to safe directory, otherwise, git commands cannot be successfully executed and thus the correct PECOS version could not be retrieved.

*Issue #, if available:*
N/A

*Description of changes:*
Added the source code folder (created by git actions checkout) to safe directory.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.