### PR TITLE
Memory-mapped Utility for PECOS XLinear Model

### DIFF
--- a/pecos/core/libpecos.cpp
+++ b/pecos/core/libpecos.cpp
@@ -37,6 +37,18 @@ extern "C" {
         return static_cast<void*>(model);
     }
 
+    void* c_xlinear_load_mmap_model_from_disk(const char* model_path, const bool pre_load) {
+        // Only implemented for bin_search_chunked
+        auto model = new pecos::HierarchicalMLModel(model_path, pecos::layer_type_t::LAYER_TYPE_BINARY_SEARCH_CHUNKED, true, pre_load);
+        return static_cast<void*>(model);
+    }
+
+    void c_xlinear_compile_mmap_model(const char* model_path, const char* mmap_model_path) {
+        // Only implemented for bin_search_chunked
+        auto model = new pecos::HierarchicalMLModel(model_path, pecos::layer_type_t::LAYER_TYPE_BINARY_SEARCH_CHUNKED);
+        model->save_mmap(mmap_model_path);
+    }
+
     void c_xlinear_destruct_model(void* ptr) {
         pecos::HierarchicalMLModel* mc = static_cast<pecos::HierarchicalMLModel*>(ptr);
         delete mc;

--- a/pecos/core/utils/matrix.hpp
+++ b/pecos/core/utils/matrix.hpp
@@ -195,7 +195,7 @@ namespace pecos {
             csr_t res;
             res.allocate(rows, cols, nnz);
             std::memcpy(res.col_idx, col_idx, sizeof(index_type) * nnz);
-            std::memcpy(res.val, val, sizeof(float) * nnz);
+            std::memcpy(res.val, val, sizeof(value_type) * nnz);
             std::memcpy(res.row_ptr, row_ptr, sizeof(mem_index_type) * (rows + 1));
             return res;
         }
@@ -328,7 +328,7 @@ namespace pecos {
             csc_t res;
             res.allocate(rows, cols, nnz);
             std::memcpy(res.row_idx, row_idx, sizeof(index_type) * nnz);
-            std::memcpy(res.val, val, sizeof(float) * nnz);
+            std::memcpy(res.val, val, sizeof(value_type) * nnz);
             std::memcpy(res.col_ptr, col_ptr, sizeof(mem_index_type) * (cols + 1));
             return res;
         }

--- a/pecos/core/utils/mmap_util.hpp
+++ b/pecos/core/utils/mmap_util.hpp
@@ -1,0 +1,355 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+#ifndef __MMAP_UTIL_H__
+#define __MMAP_UTIL_H__
+
+#define __PTR_ALIGN_BYTES 8 // Bytes to align all pointers to in a mmap file
+
+#include <fcntl.h>
+#include <math.h>
+#include <stdexcept>
+#include <stdio.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include "file_util.hpp"
+
+
+namespace pecos {
+
+namespace mmap_util {
+
+// Pad file with 0
+void _pad_file(FILE * fp, const size_t n_padded_bytes) {
+    char dummy = '\0';
+    fwrite(&dummy, sizeof(char), n_padded_bytes, fp);
+}
+
+/*
+ * Metadata for memory-mapped file
+ */
+class MmapFileMetadata {
+    public:
+        MmapFileMetadata() : _n_arr(0) {}
+
+        inline size_t n_arr() const {
+            return _n_arr;
+        }
+
+        inline uint64_t arr_elem_size(const size_t idx) const {
+            return _arr_elem_size[idx];
+        }
+
+        inline uint64_t arr_len(const size_t idx) const {
+            return _arr_len[idx];
+        }
+
+        inline uint64_t arr_offset(const size_t idx) const {
+            return _arr_offset[idx];
+        }
+
+        // Append an array's metadata, array ptr is aligned in file
+        void aligned_append(const uint64_t elem_size, const uint64_t len, size_t & n_padded_bytes) {
+            // align offset
+            uint64_t file_end = 0;
+            if (_n_arr != 0) {
+                file_end = _arr_offset.back() + _arr_elem_size.back() * _arr_len.back();
+            }
+            uint64_t aligned_offset = ceil(static_cast<double>(file_end) / __PTR_ALIGN_BYTES) * __PTR_ALIGN_BYTES;
+
+            _n_arr++;
+            _arr_elem_size.push_back(elem_size);
+            _arr_len.push_back(len);
+            _arr_offset.push_back(aligned_offset);
+
+            // return number of padded bytes
+            uint64_t n_padded_bytes_64 = aligned_offset - file_end;
+            n_padded_bytes = static_cast<size_t>(n_padded_bytes_64);
+        }
+
+        // Load metadata from file
+        void load(const std::string & file_name) {
+            // Open file and seek metadata position
+            FILE * fp = fopen(file_name.c_str(), "rb");
+            if (!fp) {
+                throw std::runtime_error("Load metadata: Open file failed.");
+            }
+            fseek(fp, -_MAX_METADATA_SIZE, SEEK_END);
+
+            // check endian
+            _check_endian_type(fp);
+
+            // load metadata
+            if (fread(&(_n_arr), sizeof(_n_arr), 1, fp) != 1) {
+                throw std::runtime_error("Read n_arr failed.");
+            }
+            if (_n_arr <= 0) {
+                throw std::runtime_error("Should get positive n_arr, got: " + std::to_string(_n_arr));
+            }
+            _load_vec(fp, _arr_elem_size, _n_arr, "arr_elem_size");
+            _load_vec(fp, _arr_len, _n_arr, "arr_len");
+            _load_vec(fp, _arr_offset, _n_arr, "arr_offset");
+
+            // Close file
+            fclose(fp);
+        }
+
+        // Dump metadata into file
+        void dump(FILE * fp) {
+            // dump endian
+            _dump_endian_type(fp);
+
+            // dump metadata
+            fwrite(&(_n_arr), sizeof(_n_arr), 1, fp);
+            _dump_vec(fp, _arr_elem_size);
+            _dump_vec(fp, _arr_len);
+            _dump_vec(fp, _arr_offset);
+
+            // Pad metadata to _MAX_METADATA_SIZE
+            size_t n_padded_bytes = _MAX_METADATA_SIZE - _get_metadata_size(_n_arr);
+            _pad_file(fp, n_padded_bytes);
+        }
+
+    private:
+        // Max number of arrays in mmap file
+        const size_t _MAX_N_ARR = 256;
+
+        // Preset metadata size, containing information of all arrays, written at end of file
+        const size_t _MAX_METADATA_SIZE = _get_metadata_size(_MAX_N_ARR);
+
+        // Metadata
+        size_t _n_arr;
+        std::vector<uint64_t> _arr_elem_size;
+        std::vector<uint64_t> _arr_len;
+        std::vector<uint64_t> _arr_offset;
+
+        // Dump machine endian type to file
+        void _dump_endian_type(FILE * fp) {
+            char endian_type = file_util::runtime();
+            fwrite(&(endian_type), sizeof(endian_type), 1, fp);
+        }
+
+        // Check whether the dumped endian type (read at FILE pointer) is the same with machine endian type
+        void _check_endian_type(FILE * fp) {
+            char endian_type;
+            if (fread(&(endian_type), sizeof(endian_type), 1, fp) != 1) {
+                throw std::runtime_error("Read endian type failed.");
+            }
+            if (file_util::different_from_runtime(endian_type)) {
+                throw std::runtime_error("Machine endian type is different from saved data, cannot memory-map load.");
+            }
+        }
+
+        void _load_vec(FILE * fp, std::vector<uint64_t> & vec, const size_t vec_len, const std::string & vec_name) {
+            vec.resize(vec_len);
+            if (fread(vec.data(), sizeof(vec[0]), vec.size(), fp) != vec.size()) {
+                throw std::runtime_error("Read " + vec_name + " failed.");
+            }
+        }
+
+        void _dump_vec(FILE * fp, std::vector<uint64_t> & vec) {
+            fwrite(vec.data(), sizeof(vec[0]), vec.size(), fp);
+        }
+
+        inline size_t _get_metadata_size(const size_t n_arr) {
+            // endian type (char) + n_arr (size_t) + arr infos (3 * n_arr * (uint64_t))
+            return sizeof(char) + sizeof(size_t) + 3 * n_arr * sizeof(uint64_t);
+        }
+}; // end class MmapFileMetadata
+
+/*
+ * Class to load a file in memory-mapped format.
+ */
+class MemoryMappedFile {
+    public:
+        MemoryMappedFile() :
+            _iter(0),
+            _mmap_size(0),
+            _mmap_ptr(nullptr) {
+        }
+
+        ~MemoryMappedFile() {
+            _free_mmap(); // This need a separate function cuz C++11 raises warning against exception in destructor
+        }
+
+        // load an instance from a file
+        void load(const std::string & file_name, const bool pre_load) {
+            _metadata.load(file_name);
+            _load_mmap(file_name, pre_load);
+            _assign_mmap_arr_ptrs();
+
+            // Initialize array iterator
+            _iter = 0;
+        }
+
+        // Get the array pointer at current iterator, the parameter `arr_len` is only for sanity check
+        template <typename T>
+        T * get_arr(const uint64_t arr_len) {
+            // Metadata Sanity checks
+            if (_iter >= _metadata.n_arr()) {
+                throw std::runtime_error("Already got all arrays, please check save/load implementation");
+            }
+            auto cur_arr_elem_size = _metadata.arr_elem_size(_iter);
+            if (cur_arr_elem_size != sizeof(T)) {
+                throw std::runtime_error("Should get array element size: " + std::to_string(cur_arr_elem_size) + ", but user requests: " + std::to_string(sizeof(T)));
+            }
+            auto cur_arr_len = _metadata.arr_len(_iter);
+            if (cur_arr_len != arr_len) {
+                throw std::runtime_error("Should get array length: " + std::to_string(cur_arr_len) + ", but user requests: " + std::to_string(arr_len));
+            }
+
+            // Cast array pointer
+            T * cur_arr_ptr = reinterpret_cast< T * >(_mmap_arr_ptr[_iter]);
+
+            // Move forward array iterator
+            _iter++;
+
+            return cur_arr_ptr;
+        }
+
+    private:
+        // Metadata
+        MmapFileMetadata _metadata;
+
+        // Internal array iterator
+        size_t _iter;
+
+        // mmap pointers
+        uint64_t _mmap_size;
+        void * _mmap_ptr;
+        std::vector<void *> _mmap_arr_ptr; // mmap pointer for each array
+
+
+        void _load_mmap(const std::string & file_name, const bool pre_load) {
+            // mmap flag
+            int mmap_flags = MAP_SHARED;
+            if (pre_load) { // pre-fault all pages to load them into memory
+                mmap_flags |= MAP_POPULATE;
+            }
+
+            // Open file
+            int fd = open(file_name.c_str(), O_RDONLY);
+            if (fd == -1) {
+                throw std::runtime_error("Load Mmap file: Open file failed.");
+            }
+
+            // File size
+            struct stat file_stat;
+            fstat(fd, &file_stat);
+            _mmap_size = file_stat.st_size;
+            if (_mmap_size <= 0) {
+                throw std::runtime_error("Memory mapped file size should be positive, got: " + std::to_string(_mmap_size));
+            }
+
+            // mmap
+            _mmap_ptr = mmap(NULL, _mmap_size, PROT_READ, mmap_flags, fd, 0);
+            if (_mmap_ptr == MAP_FAILED) {
+                throw std::runtime_error("Memory map failed.");
+            }
+
+            // Close file
+            if (close(fd) < 0) {
+                throw std::runtime_error("Close file failed.");
+            }
+        }
+
+        void _assign_mmap_arr_ptrs() {
+            _mmap_arr_ptr.resize(_metadata.n_arr());
+            for (size_t idx = 0; idx < _metadata.n_arr(); ++idx) {
+                char * cur_arr_ptr = reinterpret_cast< char * >(_mmap_ptr);
+                _mmap_arr_ptr[idx] = reinterpret_cast< void * >(cur_arr_ptr + _metadata.arr_offset(idx));
+            }
+        }
+
+        // Unmap the region
+        void _free_mmap() {
+            if (_mmap_ptr) {
+                auto res = munmap(_mmap_ptr, _mmap_size);
+                if (res == EINVAL) {
+                    throw std::runtime_error("Free memory map failed.");
+                }
+            }
+        }
+}; // end class MemoryMappedFile
+
+
+/*
+ * Dump one or several arrays into a memory-mapped file format
+ */
+class DumpToMmapFile {
+    public:
+        DumpToMmapFile(const std::string & file_name) {
+            _fp = fopen(file_name.c_str(), "wb");
+            _check_fp_open();
+        }
+
+        ~DumpToMmapFile() {
+            if (_fp) {
+                fclose(_fp);
+            }
+        }
+
+        // Dump a snapshot of the given array's memory into file
+        // Note:
+        // If the array is a struct array, memory snapshot could possibly be different across platform and compiler
+        // due to data struct padding, and user should be aware of it.
+        template <typename T>
+        void dump_arr(const T * arr, const uint64_t arr_len) {
+            _check_fp_open();
+
+            if (arr_len <= 0) {
+                throw std::runtime_error("Array length should be positive, got: " + std::to_string(arr_len));
+            }
+
+            size_t n_padded_bytes = 0;
+            _metadata.aligned_append(sizeof(T), arr_len, n_padded_bytes);
+
+            // Pad last array
+            _pad_file(_fp, n_padded_bytes);
+
+            // Dump array memory snapshot
+            fwrite(arr, sizeof(T) * arr_len, 1, _fp);
+        }
+
+        // Wrapper for vector
+        template <typename T>
+        void dump_vec(const std::vector<T> & vec) {
+            dump_arr(vec.data(), vec.size());
+        }
+
+        void finalize() {
+            _check_fp_open();
+            // Dump metadata
+            _metadata.dump(_fp);
+            fclose(_fp);
+            _fp = NULL;
+        }
+
+    private:
+        MmapFileMetadata _metadata;
+        FILE * _fp;
+
+        void _check_fp_open() {
+            if (_fp == NULL) {
+                throw std::runtime_error("File is not opened, cannot dump mmap file.");
+            }
+        }
+
+}; // end class DumpMemoryMappedFile
+
+} // end namespace mmap_util
+
+} // end namespace pecos
+
+#endif  // end of __MMAP_UTIL_H__

--- a/pecos/core/xmc/inference.hpp
+++ b/pecos/core/xmc/inference.hpp
@@ -212,90 +212,83 @@ namespace pecos {
         value_type val;
     };
 
-    struct hash_chunk_t {
+    // View of a hash chunk, does not hold any memory
+    struct hash_chunk_view_t {
         typedef typename csc_t::index_type index_type;
         typedef typename csc_t::mem_index_type mem_index_type;
         typedef typename chunk_entry_t::value_type value_type;
 
-        // Maps a matrix row index into an index of the row_ptr array below
-        unordered_map<index_type, index_type> row_hash;
         index_type col_begin; // The column this chunk starts at (inclusive)
         index_type col_end; // The column this chunk ends at (exclusive)
+        index_type nnz_rows; // The number of non-zero rows in this chunk
+        // Using index_type for struct padding
+        index_type b_has_explicit_bias; // Whether or not this chunk has an explicit bias term
+
+        // This struct does not hold memory, all pointers are only views
+        unordered_map<index_type, index_type> row_hash; // Maps a matrix row index into an index of the row_ptr array below
         mem_index_type* row_ptr; // An array of where rows begin in hash_chunked_matrix_t::entries
-        bool b_has_explicit_bias; // Whether or not this chunk has an explicit bias term
 
-        hash_chunk_t() :
-            row_ptr(nullptr),
-            b_has_explicit_bias(false) {
+
+        hash_chunk_view_t() :
+            col_begin(0),
+            col_end(0),
+            nnz_rows(0),
+            b_has_explicit_bias(false),
+            row_ptr(nullptr) {
         }
 
-        ~hash_chunk_t() {
-            if (row_ptr) {
-                delete[] row_ptr;
-            }
+        void set_row(index_type row, index_type i_row, mem_index_type i_entry) {
+            row_ptr[i_row] = i_entry;
+            row_hash[row] = i_row;
         }
 
-        void set_empty() {
-            row_ptr = nullptr;
-        }
-
-        void init(const index_type nnz_rows) {
-            row_ptr = new mem_index_type[nnz_rows + 1];
-        }
-
-        void set_row(index_type row, index_type row_indx, mem_index_type ptr) {
-            row_ptr[row_indx] = ptr;
-            row_hash[row] = row_indx;
+        index_type row_ptr_size() {
+            return nnz_rows == 0 ? (0) : (nnz_rows + 1);
         }
     };
 
-    struct bin_search_chunk_t {
+    // View of a binary search chunk, does not hold any memory
+    struct bin_search_chunk_view_t {
         typedef typename csc_t::index_type index_type;
         typedef typename csc_t::mem_index_type mem_index_type;
         typedef typename chunk_entry_t::value_type value_type;
 
         index_type col_begin; // The column this chunk starts at (inclusive)
         index_type col_end; // The column this chunk ends at (exclusive)
-        index_type* row_idx; // Stores the row id of each nnz row
-        mem_index_type* row_ptr; // Stores the pointer to data of each nnz row
-        index_type nnz_rows;
-        bool b_has_explicit_bias; // Whether or not this chunk has an explicit bias term
+        index_type nnz_rows; // The number of non-zero rows in this chunk
+        // Using index_type for struct padding
+        index_type b_has_explicit_bias; // Whether or not this chunk has an explicit bias term, 0=false
 
-        bin_search_chunk_t() :
+        // This struct does not hold memory, all pointers are only views
+        index_type* row_idx; // Stores the row id of each nnz row, size nnz_rows
+        mem_index_type* row_ptr; // Stores the pointer to data of each nnz row, size nnz_rows+1
+
+
+        bin_search_chunk_view_t() :
+            col_begin(0),
+            col_end(0),
+            nnz_rows(0),
+            b_has_explicit_bias(false),
             row_idx(nullptr),
-            row_ptr(nullptr),
-            b_has_explicit_bias(false) {
+            row_ptr(nullptr) {
         }
 
-        ~bin_search_chunk_t() {
-            if (row_ptr) {
-                delete[] row_ptr;
-            }
-            if (row_idx) {
-                delete[] row_idx;
-            }
+        void set_row(index_type row, index_type i_row, mem_index_type i_entry) {
+            row_ptr[i_row] = i_entry;
+            row_idx[i_row] = row;
         }
 
-        void set_empty() {
-            row_idx = nullptr;
-            row_ptr = nullptr;
-            nnz_rows = 0;
+        index_type row_idx_size() {
+            return nnz_rows;
         }
 
-        void init(const index_type nnz_rows) {
-            row_idx = new index_type[nnz_rows];
-            row_ptr = new mem_index_type[nnz_rows + 1];
-            this->nnz_rows = nnz_rows;
-        }
-
-        void set_row(index_type row, index_type row_indx, mem_index_type ptr) {
-            row_ptr[row_indx] = ptr;
-            row_idx[row_indx] = row;
+        index_type row_ptr_size() {
+            return nnz_rows == 0 ? (0) : (nnz_rows + 1);
         }
     };
 
     struct hash_chunked_matrix_t {
-        typedef hash_chunk_t chunk_t;
+        typedef hash_chunk_view_t chunk_t;
         typedef typename chunk_t::index_type index_type;
         typedef typename chunk_t::mem_index_type mem_index_type;
         typedef typename chunk_t::value_type value_type;
@@ -309,17 +302,34 @@ namespace pecos {
         index_type cols;
         index_type rows;
 
+        // actual memory storage
+        std::vector<chunk_t> _chunks;
+        std::vector<mem_index_type> _chunks_row_ptr;
+        std::vector<chunk_entry_t> _entries;
+
+        // NOTE: Only use this function when metadata is assigned and chunks allocated
+        void _allocate_chunks_row_ptrs(const std::vector<index_type> &chunk_nnz_rows) {
+            mem_index_type chunks_row_ptr_size = 0;
+            for (chunk_index_type i=0; i < chunk_count; ++i) {
+                auto& chunk = chunks[i];
+                if (chunk.nnz_rows != 0) {
+                    chunks_row_ptr_size += chunk.row_ptr_size();
+                }
+            }
+            _chunks_row_ptr.resize(chunks_row_ptr_size);
+            mem_index_type * tmp_row_ptr_ptr = _chunks_row_ptr.data();
+            for (chunk_index_type i=0; i < chunk_count; ++i) {
+                auto& chunk = chunks[i];
+                if (chunk.nnz_rows != 0) {
+                    chunk.row_ptr = tmp_row_ptr_ptr;
+                    tmp_row_ptr_ptr += chunk.row_ptr_size();
+                }
+            }
+        }
+
         mem_index_type get_nnz() const {
             auto& lastChunk = chunks[chunk_count - 1];
             return lastChunk.row_ptr[lastChunk.row_hash.size()];
-        }
-
-        // Frees the underlying memory of the matrix (i.e., chunk and entry arrays)
-        // Every function in the inference code that returns a matrix has allocated memory, and
-        // therefore one should call this function to free that memory.
-        void free_underlying_memory() {
-            delete[] chunks;
-            delete[] entries;
         }
 
         bool check_bias_explicit(const chunk_t& chunk) const {
@@ -328,7 +338,7 @@ namespace pecos {
     };
 
     struct bin_search_chunked_matrix_t {
-        typedef bin_search_chunk_t chunk_t;
+        typedef bin_search_chunk_view_t chunk_t;
         typedef typename chunk_t::index_type index_type;
         typedef typename chunk_t::mem_index_type mem_index_type;
         typedef typename chunk_t::value_type value_type;
@@ -342,17 +352,41 @@ namespace pecos {
         index_type cols;
         index_type rows;
 
+        // actual memory storage
+        std::vector<chunk_t> _chunks;
+        std::vector<index_type> _chunks_row_idx;
+        std::vector<mem_index_type> _chunks_row_ptr;
+        std::vector<chunk_entry_t> _entries;
+
+        // NOTE: Only use this function when metadata is assigned and chunks allocated
+        void _allocate_chunks_row_ptrs(const std::vector<index_type> &chunk_nnz_rows) {
+            mem_index_type chunks_row_idx_size = 0;
+            mem_index_type chunks_row_ptr_size = 0;
+            for (chunk_index_type i=0; i < chunk_count; ++i) {
+                auto& chunk = chunks[i];
+                if (chunk.nnz_rows != 0) {
+                    chunks_row_idx_size += chunk.row_idx_size();
+                    chunks_row_ptr_size += chunk.row_ptr_size();
+                }
+            }
+            _chunks_row_idx.resize(chunks_row_idx_size);
+            _chunks_row_ptr.resize(chunks_row_ptr_size);
+            index_type * tmp_row_idx_ptr = _chunks_row_idx.data();
+            mem_index_type * tmp_row_ptr_ptr = _chunks_row_ptr.data();
+            for (chunk_index_type i=0; i < chunk_count; ++i) {
+                auto& chunk = chunks[i];
+                if (chunk.nnz_rows != 0) {
+                    chunk.row_idx = tmp_row_idx_ptr;
+                    tmp_row_idx_ptr += chunk.row_idx_size();
+                    chunk.row_ptr = tmp_row_ptr_ptr;
+                    tmp_row_ptr_ptr += chunk.row_ptr_size();
+                }
+            }
+        }
+
         uint64_t get_nnz() const {
             auto& lastChunk = chunks[chunk_count - 1];
             return lastChunk.row_ptr[lastChunk.nnz_rows];
-        }
-
-        // Frees the underlying memory of the matrix (i.e., chunk and entry arrays)
-        // Every function in the inference code that returns a matrix has allocated memory, and
-        // therefore one should call this function to free that memory.
-        void free_underlying_memory() {
-            delete[] chunks;
-            delete[] entries;
         }
 
         bool check_bias_explicit(const chunk_t& chunk) const {
@@ -377,14 +411,49 @@ namespace pecos {
 
     // Create a chunked matrix from a csc matrix. chunk_col_idx specifies the
     // column starts of each chunk.
-    template <typename matrix_type_t, typename chunk_col_array_index_t>
-    matrix_type_t make_chunked_from_csc(const csc_t& mat,
-        const chunk_col_array_index_t chunk_col_idx[],
-        const uint32_t chunk_count) {
+    template <typename matrix_type_t>
+    void _allocate_chunked_matrix(
+        const uint32_t chunk_count,
+        const csc_t::index_type cols,
+        const csc_t::index_type rows,
+        const csc_t::mem_index_type nnz,
+        const csc_t::mem_index_type chunk_col_idx[],
+        const std::vector<typename matrix_type_t::index_type>& chunk_nnz_rows,
+        matrix_type_t& chunked_mat
+    ) {
+        // Assign metadata
+        chunked_mat.chunk_count = chunk_count;
+        chunked_mat.cols = cols;
+        chunked_mat.rows = rows;
+
+        // Allocate entries
+        chunked_mat._entries.resize(nnz);
+        chunked_mat.entries = chunked_mat._entries.data();
+
+        // Allocate chunks
+        chunked_mat._chunks.resize(chunk_count);
+        chunked_mat.chunks = chunked_mat._chunks.data();
+
+        // Assign chunks col idx
+        for (uint32_t i=0; i < chunk_count; ++i) {
+            auto& chunk = chunked_mat.chunks[i];
+            chunk.col_begin = chunk_col_idx[i];
+            chunk.col_end = chunk_col_idx[i + 1];
+            chunk.nnz_rows = chunk_nnz_rows[i];
+        }
+
+        // Allocate chunks row ptrs
+        chunked_mat._allocate_chunks_row_ptrs(chunk_nnz_rows);
+    }
+
+    template <typename matrix_type_t>
+    void make_chunked_from_csc(const csc_t& mat,
+        const csc_t::mem_index_type chunk_col_idx[],
+        const uint32_t chunk_count,
+        matrix_type_t& chunked) {
 
         typedef typename matrix_type_t::index_type index_type;
         typedef typename matrix_type_t::mem_index_type mem_index_type;
-        typedef typename std::make_signed<index_type>::type signed_index_type;
         typedef typename matrix_type_t::chunk_index_type chunk_index_type;
 
         struct chunk_nz_entry_t {
@@ -397,82 +466,87 @@ namespace pecos {
             }
         };
 
-        matrix_type_t chunked;
-        chunked.chunks = new typename matrix_type_t::chunk_t[chunk_count];
-        chunked.entries = new chunk_entry_t[mat.col_ptr[mat.cols]];
-        chunked.chunk_count = chunk_count;
-        chunked.cols = mat.cols;
-        chunked.rows = mat.rows;
-
+        // Collect chunks cols ptr
         std::vector<mem_index_type> chunk_ptr(chunk_count + 1);
-
         for (chunk_index_type i = 0; i < chunk_count; ++i) {
-            chunked.chunks[i].col_begin = chunk_col_idx[i];
-            chunked.chunks[i].col_end = chunk_col_idx[i + 1];
-            chunked.chunks[i].row_ptr = nullptr;
             chunk_ptr[i] = mat.col_ptr[chunk_col_idx[i]];
         }
         chunk_ptr[chunk_count] = mat.col_ptr[mat.cols];
 
-        std::vector<chunk_nz_entry_t> nonzeros;
+        // Collect chunks nnz_rows
+        std::vector<index_type> chunk_nnz_rows(chunk_count);
+        std::vector<chunk_entry_t::index_type> nnz_rows;
+        for (chunk_index_type i_chunk = 0; i_chunk < chunk_count; ++i_chunk) {
+            auto chunk_nnz = chunk_ptr[i_chunk + 1] - chunk_ptr[i_chunk];
+            // Empty chunk
+            if (chunk_nnz == 0) {
+                chunk_nnz_rows[i_chunk] = 0;
+                continue;
+            }
+            // Find chunk's all nonzeros row number
+            nnz_rows.resize(chunk_nnz);
+            mem_index_type i_nz = 0;
+            for (auto col = chunk_col_idx[i_chunk]; col < chunk_col_idx[i_chunk + 1]; ++col) {
+                for (auto m_col = mat.col_ptr[col]; m_col < mat.col_ptr[col + 1]; ++m_col) {
+                    nnz_rows[i_nz] = mat.row_idx[m_col];
+                    ++i_nz;
+                }
+            }
+            std::stable_sort(nnz_rows.begin(), nnz_rows.end());
+            // Count unique nonzero rows
+            chunk_nnz_rows[i_chunk] = 1; // at least 1
+            for (mem_index_type i_nz= 0; i_nz < chunk_nnz - 1; ++i_nz) {
+                chunk_nnz_rows[i_chunk] += (nnz_rows[i_nz] != nnz_rows[i_nz + 1]);
+            }
+        }
 
+        // Allocate
+        _allocate_chunked_matrix<matrix_type_t>(
+            chunk_count, mat.cols, mat.rows, mat.col_ptr[mat.cols],
+            chunk_col_idx, chunk_nnz_rows, chunked);
+
+        // Assign chunks row idx & ptrs value
+        std::vector<chunk_nz_entry_t> nonzeros;
         for (chunk_index_type i_chunk = 0; i_chunk < chunk_count; ++i_chunk) {
             auto& chunk = chunked.chunks[i_chunk];
             mem_index_type chunk_nnz = chunk_ptr[i_chunk + 1] - chunk_ptr[i_chunk];
 
-            // No nonzeros, no problem!
-            if (chunk_nnz == 0) {
-                chunk.set_empty();
+            // Ignore empty chunks
+            if (chunk.nnz_rows == 0) {
                 continue;
             }
 
-            nonzeros.resize(chunk_nnz);
-
             // Collect nonzeros
+            nonzeros.resize(chunk_nnz);
             mem_index_type i_nz = 0;
-            for (index_type col = chunk.col_begin; col < chunk.col_end; ++col) {
-                mem_index_type col_begin = mat.col_ptr[col];
-                mem_index_type col_end = mat.col_ptr[col + 1];
-                for (mem_index_type i = col_begin; i < col_end; ++i) {
-                    auto& entry = nonzeros[i_nz++];
-                    entry.row = mat.row_idx[i];
-                    entry.col = col;
-                    entry.val = mat.val[i];
+            for (auto col = chunk.col_begin; col < chunk.col_end; ++col) {
+                for (auto m_col = mat.col_ptr[col]; m_col < mat.col_ptr[col + 1]; ++m_col) {
+                    auto& nz_entry = nonzeros[i_nz++];
+                    nz_entry.row = mat.row_idx[m_col];
+                    nz_entry.col = col;
+                    nz_entry.val = mat.val[m_col];
                 }
             }
-
             // Sort by row, remains sorted by columns
             std::stable_sort(nonzeros.begin(), nonzeros.end());
 
-            // Count the number of nz rows
-            index_type nz_rows = 1;
-            for (mem_index_type i = 0; i < chunk_nnz - 1; ++i) {
-                nz_rows += (nonzeros[i].row != nonzeros[i + 1].row);
-            }
-
-            // Allocate memory for chunk
-            chunk.init(nz_rows);
-
-            chunk.row_ptr[nz_rows] = mat.col_ptr[chunk.col_end];
-
-            mem_index_type chunk_offset = chunk_ptr[i_chunk];
-            signed_index_type last_row = -1;
+            // Assign all nonzero entries
+            chunk.row_ptr[chunk.nnz_rows] = mat.col_ptr[chunk.col_end];
+            index_type last_row = static_cast<index_type>(-1);
             index_type i_nz_row = 0;
-            for (mem_index_type i = 0, entry_location = chunk_offset; i < chunk_nnz; ++i, ++entry_location) {
-                auto& entry = nonzeros[i];
-
+            for (mem_index_type i_nz = 0, i_entry = chunk_ptr[i_chunk]; i_nz < nonzeros.size(); ++i_nz, ++i_entry) {
+                auto& nz_entry = nonzeros[i_nz];
+                // Assign the chunk's row
                 // The row has changed, save the row's metadata into the chunk
-                if ((signed_index_type) entry.row != last_row) {
-                    chunk.set_row(entry.row, i_nz_row, entry_location);
+                if (nz_entry.row != last_row) {
+                    chunk.set_row(nz_entry.row, i_nz_row, i_entry);
                     ++i_nz_row;
-                    last_row = entry.row;
+                    last_row = nz_entry.row;
                 }
-
-                chunked.entries[entry_location].col_offset = entry.col - chunk.col_begin;
-                chunked.entries[entry_location].val = entry.val;
+                chunked.entries[i_entry].col_offset = nz_entry.col - chunk.col_begin;
+                chunked.entries[i_entry].val = nz_entry.val;
             }
         }
-        return chunked;
     }
 
     // Checks if the rows of C (i.e., the children nodes) are contiguously ordered.
@@ -494,29 +568,26 @@ namespace pecos {
     }
 
     template <typename matrix_t>
-    matrix_t make_chunked_W_from_layer_matrices(const csc_t& W, const csc_t& C,
-        bool b_use_bias) {
+    void make_chunked_W_from_layer_matrices(const csc_t& W, const csc_t& C,
+        const bool b_use_bias, matrix_t& chunked_W) {
 
         typedef typename matrix_t::chunk_index_type chunk_index_t;
-        typedef typename csc_t::mem_index_type index_t;
 
         // Make sure that the rows of C are contiguous in order of parent node
-        matrix_t result = make_chunked_from_csc<matrix_t, index_t>(W, C.col_ptr, C.cols);
+        make_chunked_from_csc<matrix_t>(W, C.col_ptr, C.cols, chunked_W);
 
         // Precompute whether each chunk actually has a bias term.
         if (b_use_bias) {
-            for (chunk_index_t i_chunk = 0; i_chunk < result.chunk_count; ++i_chunk) {
-                auto& chunk = result.chunks[i_chunk];
-                chunk.b_has_explicit_bias = result.check_bias_explicit(chunk);
+            for (chunk_index_t i_chunk = 0; i_chunk < chunked_W.chunk_count; ++i_chunk) {
+                auto& chunk = chunked_W.chunks[i_chunk];
+                chunk.b_has_explicit_bias = chunked_W.check_bias_explicit(chunk);
             }
         } else {
-            for (chunk_index_t i_chunk = 0; i_chunk < result.chunk_count; ++i_chunk) {
-                auto& chunk = result.chunks[i_chunk];
+            for (chunk_index_t i_chunk = 0; i_chunk < chunked_W.chunk_count; ++i_chunk) {
+                auto& chunk = chunked_W.chunks[i_chunk];
                 chunk.b_has_explicit_bias = false;
             }
         }
-
-        return result;
     }
 
     // Defines templated operations for vector x chunk products
@@ -536,7 +607,7 @@ namespace pecos {
         // Compute the inner product of a vector and chunk in hash format.
         // Inner product is computed via hash table lookup.
         static void compute_chunk_inner_product_write_to_zeroed_block(
-            const csr_t::row_vec_t& v, const hash_chunk_t& chunk,
+            const csr_t::row_vec_t& v, const hash_chunk_view_t& chunk,
             const hash_chunked_matrix_t& chunk_matrix,
             typename hash_chunked_matrix_t::value_type* output_block,
             typename hash_chunked_matrix_t::value_type bias, bool b_use_bias) {
@@ -564,7 +635,7 @@ namespace pecos {
     template <>
     struct chunk_ops<typename drm_t::row_vec_t, hash_chunked_matrix_t> {
         static void compute_chunk_inner_product_write_to_zeroed_block(
-            const drm_t::row_vec_t& v, const hash_chunk_t& chunk,
+            const drm_t::row_vec_t& v, const hash_chunk_view_t& chunk,
             const hash_chunked_matrix_t& chunk_matrix,
             typename hash_chunked_matrix_t::value_type* output_block,
             typename hash_chunked_matrix_t::value_type bias, bool b_use_bias) {
@@ -601,7 +672,7 @@ namespace pecos {
         // Compute the inner product of a vector and chunk in binary search format.
         // Inner product is computed via binary search.
         static void compute_chunk_inner_product_write_to_zeroed_block(
-            const csr_t::row_vec_t& v, const bin_search_chunk_t& chunk,
+            const csr_t::row_vec_t& v, const bin_search_chunk_view_t& chunk,
             const bin_search_chunked_matrix_t& chunk_matrix,
             typename bin_search_chunked_matrix_t::value_type* output_block,
             typename bin_search_chunked_matrix_t::value_type bias, bool b_use_bias) {
@@ -644,7 +715,7 @@ namespace pecos {
     template <>
     struct chunk_ops<typename drm_t::row_vec_t, bin_search_chunked_matrix_t> {
         static void compute_chunk_inner_product_write_to_zeroed_block(
-            const typename drm_t::row_vec_t& v, const bin_search_chunk_t& chunk,
+            const typename drm_t::row_vec_t& v, const bin_search_chunk_view_t& chunk,
             const bin_search_chunked_matrix_t& chunk_matrix,
             typename bin_search_chunked_matrix_t::value_type* output_block,
             typename bin_search_chunked_matrix_t::value_type bias, bool b_use_bias) {
@@ -1386,26 +1457,30 @@ namespace pecos {
         const uint32_t cur_depth,
         IModelLayer<index_type, value_type>* model) {
         MLModelMetadata metadata(folderpath + "/param.json");
+
+        // Load npz matrices. These are large data struct contains multiple vectors
         std::string w_npz_path = folderpath + "/W.npz";
         std::string c_npz_path = folderpath + "/C.npz";
-        ScipyCscF32Npz W;
-        ScipyCscF32Npz C;
-        csc_t py_matrix_csc_C;
-        csc_t py_matrix_csc_W;
-
-        W.load(w_npz_path);
+        ScipyCscF32Npz * npz_W = new ScipyCscF32Npz;
+        ScipyCscF32Npz * npz_C = new ScipyCscF32Npz;
+        npz_W->load(w_npz_path);
         if ((cur_depth == 0) && (access(c_npz_path.c_str(), F_OK) != 0)) {
             // this is to handle the case where the root layer does not have code saved.
-            C.fill_ones(W.cols(), 1);
+            npz_C->fill_ones(npz_W->cols(), 1);
         } else {
-            C.load(c_npz_path);
+            npz_C->load(c_npz_path);
         }
 
         // We perform a deep copy because MLModel assumes ownership of the memory.
-        py_matrix_csc_C = csc_npz_to_csc_t_deep_copy(C);
-        py_matrix_csc_W = csc_npz_to_csc_t_deep_copy(W);
+        csc_t csc_C = csc_npz_to_csc_t_deep_copy(* npz_C);
+        csc_t csc_W = csc_npz_to_csc_t_deep_copy(* npz_W);
 
-        model->init(py_matrix_csc_W, py_matrix_csc_C, cur_depth, true, metadata);
+        // Free npz matrices to reduce memory footprint
+        delete npz_W;
+        delete npz_C;
+
+        // Init model
+        model->init(csc_W, csc_C, cur_depth, true, metadata);
     }
 
     template <typename index_type, typename value_type>
@@ -1612,13 +1687,13 @@ namespace pecos {
                 }
 
                 this->b_children_reordered = true;
-                this->W = make_chunked_W_from_layer_matrices<chunked_matrix_t>(W_rearranged, C_rearranged, b_has_bias);
+                make_chunked_W_from_layer_matrices<chunked_matrix_t>(W_rearranged, C_rearranged, b_has_bias, this->W);
                 this->C = C_rearranged;
                 W_rearranged.free_underlying_memory();
             }
             else {
                 this->b_children_reordered = false;
-                this->W = make_chunked_W_from_layer_matrices<chunked_matrix_t>(_W, _C, b_has_bias);
+                make_chunked_W_from_layer_matrices<chunked_matrix_t>(_W, _C, b_has_bias, this->W);
                 this->C = _C;
 
                 if (b_assumes_ownership) {
@@ -1636,11 +1711,8 @@ namespace pecos {
 
         // Frees all memory that is owned by this class
         ~LayerData() {
-            W.free_underlying_memory();
             C.free_underlying_memory();
         }
-
-
     };
 
     template <typename w_matrix_t>
@@ -2052,12 +2124,9 @@ namespace pecos {
     public:
         // Initialize this model by creating all layers
         void init(std::vector<ISpecializedModelLayer*>& layers) {
-
             // Destroy all memory associated with this layer
             destroy_layers();
-
             model_layers = layers;
-
         }
 
         HierarchicalMLModel() {}

--- a/pecos/xmc/base.py
+++ b/pecos/xmc/base.py
@@ -726,6 +726,20 @@ class MLModel(pecos.BaseClass):
             param = json.loads(fin.read())
         return cls.PredParams.from_dict(param["pred_kwargs"])
 
+    @classmethod
+    def compile_mmap_model(cls, npz_folder, mmap_folder):
+        """
+        Compile model from npz format to memory-mapped format
+        for faster loading and referencing.
+        Args:
+            npz_folder (str): The source folder path for xlinear npz model.
+            mmap_folder (str): The destination folder path for xlinear mmap model.
+        """
+        param = json.loads(open(f"{npz_folder}/param.json", "r", encoding="utf-8").read())
+        assert param["model"] == cls.__name__
+
+        clib.xlinear_compile_mmap_model(npz_folder, mmap_folder)
+
     def save(self, folder):
         """Save MLModel to file
 

--- a/pecos/xmc/xlinear/model.py
+++ b/pecos/xmc/xlinear/model.py
@@ -133,6 +133,23 @@ class XLinearModel(pecos.BaseClass):
         )
         return cls(model)
 
+    @classmethod
+    def compile_mmap_model(cls, npz_folder, mmap_folder):
+        """
+        Compile xlinear model from npz format to memory-mapped format
+        for faster loading and referencing.
+        Args:
+            npz_folder (str): The source folder path for xlinear npz model.
+            mmap_folder (str): The destination folder path for xlinear mmap model.
+        """
+        import shutil
+
+        shutil.copyfile(path.join(npz_folder, "param.json"), path.join(mmap_folder, "param.json"))
+
+        HierarchicalMLModel.compile_mmap_model(
+            path.join(npz_folder, "ranker"), path.join(mmap_folder, "ranker")
+        )
+
     @property
     def is_predict_only(self):
         """


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

This pull request will consist of following 3 commits:

* Refactor chunked matrix for PECOS XLinear model inference
  * Concatenated original chunked matrix's fragmented memory allocation
    * For accommodating subsequent memory-mapped utility module.
    * This change increases time cost of making chunked matrix by 10%~15% for large models (>50G), but is necessary and cannot be avoided.
  * Reduced memory footprint of making chunked matrix 
* Memory-mapped utility module
  * Easy to use, well-encapsulated tool designed for dumping/loading arbitrary PECOS model 
* Memory-mapped PECOS XLinear model
  * Greatly reduce loading time. 
  * Ideal for large models that user want to quickly try a few inferences without waiting for loading full model into memory.
  * Also capable for large model inference that could not be stored in memory.


Usage:
User needs to have a XLinear Model saved on disk (in original `.npz` format), and manually compile into mmap format by calling `compile_mmap_model`:
```
import sys
from pecos.xmc.xlinear.model import XLinearModel


npz_model_path = f"/path/to/xlinear/pecos-models/"
mmap_model_path = f"/path/to/xlinear/mmap-models/"

print(f"Compiling mmap model from: {npz_model_path}, will save to : {mmap_model_path}...")
XLinearModel.compile_mmap_model(npz_model_path, mmap_model_path)
print("mmap model saved.")
```
Then user can load the memory-mapped model and do inference:
```
import sys
from pecos.xmc.xlinear.model import XLinearModel


mmap_model_path = f"/path/to/xlinear/mmap-models/"

# Load model
if sys.argv[2] == "--cmmap":
    print("Loading C/C++ mem map model...")
    xlm = XLinearModel.load(mmap_model_path, is_predict_only=True, is_mmap=True)
elif sys.argv[2] == "--cmmap-preload":
    print("Loading C/C++ mem map model pre-loaded...")
    xlm = XLinearModel.load(mmap_model_path, is_predict_only=True, is_mmap=True, pre_load=True)
else:
    print(f"Wrong option: {sys.argv[2]}")

# Load test data
Xt = XLinearModel.load_feature_matrix(f"/test/data/validation/X.npz")
Yt = XLinearModel.load_label_matrix(f"/test/data/validation/Y.npz")

# Predict
Yt_pred = xlm.predict(Xt)
Yt_pred = Yt_pred.tocsr()
metric = smat_util.Metrics.generate(Yt, Yt_pred, topk=10)
print(metric)
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.