### PR TITLE
Temporarily Pin setuptools<=60.0 in Wheel Build

### DIFF
--- a/.github/build_pypi_wheel.sh
+++ b/.github/build_pypi_wheel.sh
@@ -20,7 +20,10 @@ echo "pip: $($PIP --version)"
 
 # Install dependencies
 echo "Install dependencies..."
-$PIP install setuptools wheel twine auditwheel
+# Temporarily pin setuptools version due to a recent bug, which will be fix in their later updates
+# See: https://github.com/pypa/setuptools/issues/3532
+# https://github.com/numpy/numpy/issues/22135
+$PIP install 'setuptools<=60.0.*' wheel twine auditwheel
 
 # Install OpenBLAS
 # Using Numpy pre-build OpenBLAS lib v0.3.19 hosted on Anaconda


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Temporarily pin setuptools version <=60.0.* due to their recent upgrade misconsiderations that removed `disutils` module, which will be fixed in their later updates.
See: 
https://github.com/pypa/setuptools/issues/3532 
https://github.com/numpy/numpy/issues/22135


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.