### PR TITLE
accelerate clustering with sparse-dense vector and parallel sorting

### DIFF
--- a/pecos/__init__.py
+++ b/pecos/__init__.py
@@ -38,7 +38,7 @@ class BaseClass(metaclass=MetaClass):
         return MetaClass.class_fullname(cls)
 
     @classmethod
-    def append_meta(cls, d: dict = None):
+    def append_meta(cls, d=None):
         meta = {"__meta__": {"class_fullname": cls.class_fullname()}}
         if d is not None:
             meta.update(d)

--- a/pecos/core/utils/parallel.hpp
+++ b/pecos/core/utils/parallel.hpp
@@ -18,6 +18,8 @@
 #include <iterator>
 #include <numeric>
 #include <omp.h>
+// for __gnu_parallel
+#include <parallel/algorithm>
 
 namespace pecos {
 
@@ -68,6 +70,19 @@ namespace pecos {
                     );
                 }
             }
+        }
+    }
+
+    template<class InputIt, class Compare>
+    void parallel_sort(InputIt first, InputIt last, Compare comp, int threads=-1) {
+        threads = set_threads(threads);
+        typedef typename std::iterator_traits<InputIt>::difference_type difference_type;
+        difference_type len = last - first;
+        if(threads == 1 || len < threads) {
+            std::sort(first, last, comp);
+        } else {
+            __gnu_parallel::multiway_mergesort_tag parallelism(threads);
+            __gnu_parallel::sort(first, last, comp, parallelism);
         }
     }
 } // end namespace pecos

--- a/pecos/core/utils/tfidf.hpp
+++ b/pecos/core/utils/tfidf.hpp
@@ -25,8 +25,6 @@
 #include <string>
 #include <sys/stat.h>
 #include <vector>
-// for __gnu_parallel
-#include <parallel/algorithm>
 
 // string_view available since c++17
 // only in experimental/string_view in c++14
@@ -295,18 +293,6 @@ void append_lines_to_string_view(char* buffer, size_t buffer_size, sv_vec_t& lin
     }
 }
 
-template<class InputIt, class Compare>
-void parallel_sort(InputIt first, InputIt last, Compare comp, int threads=-1) {
-    threads = set_threads(threads);
-    typedef typename std::iterator_traits<InputIt>::difference_type difference_type;
-    difference_type len = last - first;
-    if(threads == 1 || len < threads) {
-        std::sort(first, last, comp);
-    } else {
-        __gnu_parallel::multiway_mergesort_tag parallelism(threads);
-        __gnu_parallel::sort(first, last, comp, parallelism);
-    }
-}
 
 class Tokenizer {
 public:


### PR DESCRIPTION
*Issue #, if available:*

Description of changes: Current PECOS hierarchical clustering implementation stores clustering centers as dense vectors, which leads to O(2^(L-1)*d ) cost for layer L, where d is the total feature dimension and can be millions or more. In extremely large datasets, at a bottom layer, L is large while the center vectors are sparse, which makes operations on dense vectors inefficient. Empirically, we find this makes bottom layers more than 10x slower than top layers on large datasets. We  apply sparse-dense vectors (sdvec) as an alternative to store centers whose time complexity is O(2^L * p), where p is the averaged number of on-zero elements of sparse center vectors, and is significantly smaller than d at bottom layers. 

With sdvec, the computational bottleneck switches from bottom layers to the top layer since the top layer performs sorting on the whole dataset. We further accelerate clustering training via parallel sorting.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.