### PR TITLE
Pin build-pypi-wheel runner image to ubuntu-20.04

### DIFF
--- a/.github/workflows/build_pypi.yml
+++ b/.github/workflows/build_pypi.yml
@@ -12,7 +12,7 @@ jobs:
         python-version: [3.6, 3.7, 3.8, 3.9]
         build_platform: ["manylinux2014_x86_64", "manylinux2014_aarch64"]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
As of Nov 9th, Github is experimenting with  transitioning `ubuntu-latest` label  to the Ubuntu 22.04 runner image. "During the transition, the label might refer to the runner image for either Ubuntu 20.04 or 22.04." which means if we get **lucky**, our `build_pypi` action will run on `ubuntu-22.04`-enabled runner and that will definitely fail `python3.6` sub-job since it is not prebuilt by GitHub therefore not available with Github action `setup-python` for the new ubuntu 22.04.

More information: https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/

Ubuntu-18.04 is marked as deprecated and will be moved out of Github runner in the future, see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources. Moreover, the Python version is also slowly migrating towards 3.10 and deprecating 3.6, which PECOS future supported versions might be aware of and we will hold a discussion and PR to upgrade in the future.

*Issue #, if available:*
N/A

*Description of changes:*
Changed `build-pypi` action to run on `ubuntu-20.04`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.