### PR TITLE
Add memory-mapped utilility module

### DIFF
--- a/pecos/core/utils/mmap_util.hpp
+++ b/pecos/core/utils/mmap_util.hpp
@@ -36,7 +36,7 @@ namespace pecos {
 
 namespace mmap_util {
 
-namespace _details { // namespace for Module Private classes
+namespace details_ { // namespace for Module Private classes
 
 /* Type constraint for mmap save/load.
  * Please beware, this is only a minimum requirement and not a guarantee that the type is platform-portable for mmap.
@@ -51,7 +51,7 @@ using if_simple_serializable = std::enable_if_t<IsPlainOldData<Type>, Ret>;
 /*
  * Module Private Class to store signature and metadata of all data blocks in mainbody for a memory-mapped file.
  */
-class _MmapFileMetadata {
+class MmapMetadata {
     public:
         struct MetaInfo{
             uint64_t offset; // Starting position of each block in the file
@@ -61,65 +61,64 @@ class _MmapFileMetadata {
 
         /* Save metadata to file.
          * Parameters:
-         *      fp (FILE *) : File pointer.
+         *      fp (FILE*) : File pointer.
          *          Must points to the end of an opened file and waits for dumping metadata.
          */
-        void save(FILE * fp) const {
+        void save(FILE* fp) const {
             uint64_t meta_offset = static_cast<uint64_t>(ftell(fp)); // Record metadata offset
-            _Signature sig = _Signature(meta_offset);
+            Signature sig = Signature(meta_offset);
 
-            file_util::fput_one<uint64_t>(_info.size(), fp);
-            file_util::fput_multiple<MetaInfo>(_info.data(), _info.size(), fp);
+            file_util::fput_one<uint64_t>(info_.size(), fp);
+            file_util::fput_multiple<MetaInfo>(info_.data(), info_.size(), fp);
 
             sig.save(fp);
         }
 
         /* Load metadata from file.
          * Parameters:
-         *      fp (FILE *) : File pointer.
+         *      fp (FILE*) : File pointer.
          *          Load signature first, then rewind to load metadata.
          */
-        void load(FILE * fp) {
-            _Signature sig;
+        void load(FILE* fp) {
+            Signature sig;
             sig.load(fp);
 
             fseek(fp, sig.meta_offset, SEEK_SET); // Rewind fp for loading metadata
             uint64_t n_block = file_util::fget_one<uint64_t>(fp);
-            _info.resize(n_block);
-            file_util::fget_multiple<MetaInfo>(_info.data(), n_block, fp);
+            info_.resize(n_block);
+            file_util::fget_multiple<MetaInfo>(info_.data(), n_block, fp);
         }
 
-        /* Append a new block's metadata with starting position aligned to at least multiple of sizeof(int)
-         * Parameters:
-         *      size (uint64_t): Number of bytes for the new block's data.
+        /* Get number of bytes to pad in order to align new block's beginning to multiple of N_ALIGN_BYTES_
          * Return:
          *      n_bytes_to_pad (uint64_t): Number of bytes to pad before saving the new block.
          */
-        uint64_t aligned_append(const uint64_t size) {
-            const uint64_t align_bytes = 16; // All blocks are aligned to multiple of the value
-
-            uint64_t last_end = 0;
-            if (_info.size() > 0) {
-                auto last_info = _info.back();
-                last_end = last_info.offset + last_info.size;
-            }
-
-            uint64_t n_bytes_to_pad = (align_bytes - (last_end % align_bytes)) % align_bytes;
-            _info.emplace_back(last_end + n_bytes_to_pad, size);
-
+        uint64_t get_n_bytes_padding_to_align() const {
+            uint64_t last_end = get_last_block_end_();
+            uint64_t n_bytes_to_pad = (N_ALIGN_BYTES_ - (last_end % N_ALIGN_BYTES_)) % N_ALIGN_BYTES_;
             return n_bytes_to_pad;
+        }
+
+        /* Append a new block's metadata giving size. Offset is auto calculated.
+         * Parameters:
+         *      size (uint64_t): Number of bytes for the new block's data.
+         */
+        void append(const uint64_t size) {
+            uint64_t last_end = get_last_block_end_();
+            uint64_t n_bytes_to_pad = get_n_bytes_padding_to_align();
+            info_.emplace_back(last_end + n_bytes_to_pad, size);
         }
 
         /* Iterator for retrieving next block's offset/size and auto advance */
         MetaInfo next() {
-            auto cur_iter = _iter;
-            _iter += 1;
-            return MetaInfo(_info[cur_iter].offset, _info[cur_iter].size);
+            auto cur_iter = iter_;
+            iter_ += 1;
+            return MetaInfo(info_[cur_iter].offset, info_[cur_iter].size);
         }
 
     private:
         /* Struct to store signature for various configuration info of a memory-mapped file */
-        struct _Signature {
+        struct Signature {
             const uint8_t SIG_SIZE = 16u;                              // Size of signature is 16 bytes
             // Signture data
             const uint8_t MAGIC[6] = {0x93u, 'P', 'E', 'C', 'O', 'S'}; // 6 bytes
@@ -127,12 +126,12 @@ class _MmapFileMetadata {
             const uint8_t version = __MMAP_UTIL_VER;                   // 1 bytes
             uint64_t meta_offset;                                      // 8 bytes
 
-            _Signature(uint64_t meta_offset=0) : endianness(get_endianess()), meta_offset(meta_offset) {}
+            Signature(uint64_t meta_offset=0) : endianness(get_endianess()), meta_offset(meta_offset) {}
 
             /* Save signature to file.
              * Signature must be saved at the end of file,
              * i.e. save when everything else has already been saved. */
-            void save(FILE *fp) const {
+            void save(FILE* fp) const {
                 file_util::fput_multiple<uint8_t>(&MAGIC[0], sizeof(MAGIC), fp);
                 file_util::fput_one<uint8_t>(endianness, fp);
                 file_util::fput_one<uint8_t>(version, fp);
@@ -140,14 +139,14 @@ class _MmapFileMetadata {
             }
 
             /* Load signature from last `SIG_SIZE` bytes of file. */
-            void load(FILE *fp) {
+            void load(FILE* fp) {
                 // Seek last `SIG_SIZE` bytes
                 fseek(fp, 0 - static_cast<long>(SIG_SIZE), SEEK_END);
                 // Check MAGIC
                 uint8_t loaded_magic[sizeof(MAGIC)];
                 file_util::fget_multiple<uint8_t>(&loaded_magic[0], sizeof(MAGIC), fp);
                 if(std::memcmp(&MAGIC[0], &loaded_magic[0], sizeof(MAGIC)) != 0) {
-                    throw std::runtime_error("File is not a valid PECOS MMAP file");
+                    throw std::runtime_error("File is not a valid PECOS MMAP file.");
                 }
                 // Check endianness
                 uint8_t loaded_endianness = file_util::fget_one<uint8_t>(fp);
@@ -169,28 +168,39 @@ class _MmapFileMetadata {
             }
         };
 
-        std::vector<MetaInfo> _info; // offset and size of each block in the file
-        uint64_t _iter = 0; // Iterator index for retrieving metadata info in blocks order
-}; // end class _MmapFileMetadata
+        const uint64_t N_ALIGN_BYTES_ = 16; // All blocks are aligned to multiple of the value
+        std::vector<MetaInfo> info_; // offset and size of each block in the file
+        uint64_t iter_ = 0; // Iterator index for retrieving metadata info in blocks order
+
+        /* Return end of last block in file */
+        uint64_t get_last_block_end_() const {
+            uint64_t last_end = 0;
+            if (info_.size() > 0) {
+                auto last_info = info_.back();
+                last_end = last_info.offset + last_info.size;
+            }
+            return last_end;
+        }
+}; // end class MmapMetadata
 
 
 /*
  * Module Private Class to load data from a memory-mapped file.
  */
-class _MmapFileLoad {
+class MmapStoreLoad {
     public:
         /* Constructor loads from memory-mapped file name
          * Parameters:
-         *      file_name (const std::string &): Name of file to load from.
+         *      file_name (const std::string&): Name of file to load from.
          *      pre_load (const bool): Whether to pre-fault all pages into memory before accessing.
          */
-        _MmapFileLoad(const std::string & file_name, const bool pre_load) {
+        MmapStoreLoad(const std::string& file_name, const bool pre_load) {
             // Load metadata first
-            FILE * fp = fopen(file_name.c_str(), "rb");
+            FILE* fp = fopen(file_name.c_str(), "rb");
             if (!fp) {
                 throw std::runtime_error("Load metadata: Open file failed.");
             }
-            _metadata.load(fp);
+            metadata_.load(fp);
             if (fclose(fp) != 0) {
                 throw std::runtime_error("Load metadata: Close file failed.");
             }
@@ -200,21 +210,21 @@ class _MmapFileLoad {
             if (fd == -1) {
                 throw std::runtime_error("Load Mmap file: Open file failed.");
             }
-            _load_mmap(fd, pre_load);
+            load_mmap_(fd, pre_load);
             if (close(fd) < 0) {
                 throw std::runtime_error("Load Mmap file: Close file failed.");
             }
         }
         /* Destructor frees the memory-mapped region */
-        ~_MmapFileLoad() { _free_mmap(); }
+        ~MmapStoreLoad() { free_mmap_(); }
 
         /* Load a simple-serializable vector(array)
          * Parameters:
          *      n_elements (uint64_t): Number of elements to load for the array.
          */
         template<class T, class TT=T, if_simple_serializable<TT> = true>
-        T * fget_multiple(uint64_t n_elements) {
-            auto meta_info = _metadata.next();
+        T* fget_multiple(uint64_t n_elements) {
+            auto meta_info = metadata_.next();
 
             // Verification
             if (n_elements * static_cast<uint64_t>(sizeof(T)) != meta_info.size) {
@@ -224,28 +234,28 @@ class _MmapFileLoad {
                     " bytes not equal. Please double check.");
             }
 
-            return reinterpret_cast< T * >(reinterpret_cast< char * >(_mmap_ptr) + meta_info.offset);
+            return reinterpret_cast< T* >(reinterpret_cast< char * >(mmap_ptr_) + meta_info.offset);
         }
 
         /* Load one element */
-        template<class T>
+        template<class T, class TT=T, if_simple_serializable<TT> = true>
         T fget_one() { // Call fget_multiple
-            return * fget_multiple<T>(1u);
+            return *fget_multiple<T>(1u);
         }
 
     private:
-        _MmapFileMetadata _metadata; // Metadata
-        void * _mmap_ptr = nullptr; // Memory-mapped pointer
-        uint64_t _mmap_size = 0;// Memory-mapped file size
+        MmapMetadata metadata_; // Metadata
+        void* mmap_ptr_ = nullptr; // Memory-mapped pointer
+        uint64_t mmap_size_ = 0; // Memory-mapped file size
 
         /* Create memory-mapped region */
-        void _load_mmap(const int fd, const bool pre_load) {
+        void load_mmap_(const int fd, const bool pre_load) {
             // Get file size
             struct stat file_stat;
             fstat(fd, &file_stat);
-            _mmap_size = file_stat.st_size;
-            if (_mmap_size <= 0) {
-                throw std::runtime_error("Memory mapped file size should be positive, got: " + std::to_string(_mmap_size));
+            mmap_size_ = file_stat.st_size;
+            if (mmap_size_ <= 0) {
+                throw std::runtime_error("Memory mapped file size should be positive, got: " + std::to_string(mmap_size_));
             }
 
             // Creat mmap
@@ -253,119 +263,121 @@ class _MmapFileLoad {
             if (pre_load) { // pre-fault all pages to load them into memory
                 mmap_flags |= MAP_POPULATE;
             }
-            _mmap_ptr = mmap(NULL, _mmap_size, PROT_READ, mmap_flags, fd, 0);
-            if (_mmap_ptr == MAP_FAILED) {
+            mmap_ptr_ = mmap(NULL, mmap_size_, PROT_READ, mmap_flags, fd, 0);
+            if (mmap_ptr_ == MAP_FAILED) {
                 throw std::runtime_error("Memory map failed.");
             }
         }
 
         /* Free memory-mapped region */
-        void _free_mmap() {
-            if (_mmap_ptr) {
-                auto res = munmap(_mmap_ptr, _mmap_size);
+        void free_mmap_() {
+            if (mmap_ptr_) {
+                auto res = munmap(mmap_ptr_, mmap_size_);
                 if (res == EINVAL) {
                     throw std::runtime_error("Free memory map failed.");
                 }
-                _mmap_ptr = nullptr;
-                _mmap_size = 0;
+                mmap_ptr_ = nullptr;
+                mmap_size_ = 0;
             }
         }
-}; // end class MmapFileLoad
+}; // end class MmapStoreLoad
 
 
 /*
  * Module Private Class to save a series of data, along with metadata and signature into a memory-mapped file.
  */
-class _MmapFileSave {
+class MmapStoreSave {
     public:
         /* Constructor to open a file and save to given filename */
-        _MmapFileSave(const std::string & file_name) {
-            _fp = fopen(file_name.c_str(), "wb");
-            if (!_fp) {
-                throw std::runtime_error("MmapFileSave: Open file failed.");
+        MmapStoreSave(const std::string& file_name) {
+            fp_ = fopen(file_name.c_str(), "wb");
+            if (!fp_) {
+                throw std::runtime_error("MmapStoreSave: Open file failed.");
             }
         }
 
         /* Destructor to save metadata and close opened file after save */
-        ~_MmapFileSave() { _finalize(); }
+        ~MmapStoreSave() { finalize_(); }
 
         /* Save a simple-serializable vector(array) */
         template<class T, class TT=T, if_simple_serializable<TT> = true>
-        void fput_multiple(const T * src, const uint64_t n_elements) {
-            auto n_bytes_to_pad = _metadata.aligned_append(sizeof(T) * n_elements);
-
-            // Pad previous block end with dummy bytes
+        void fput_multiple(const T* src, const uint64_t n_elements) {
+            // Data size
+            uint64_t size = sizeof(T) * n_elements;
+            // Pad previous block with dummy bytes to make sure new block is aligned
+            auto n_bytes_to_pad = metadata_.get_n_bytes_padding_to_align();
             const char dummy = '\0';
             for(auto i = 0u; i < n_bytes_to_pad; i++){
-                file_util::fput_one(dummy, _fp);
+                file_util::fput_one(dummy, fp_);
             }
-
             // Save array
-            file_util::fput_multiple<T>(src, n_elements, _fp);
+            metadata_.append(size);
+            file_util::fput_multiple<T>(src, n_elements, fp_);
         }
 
         /* Save one element */
-        template<class T>
+        template<class T, class TT=T, if_simple_serializable<TT> = true>
         void fput_one(const T& src) { // Call fput_multiple
             fput_multiple<T>(&src, 1u);
         }
 
     private:
-        _MmapFileMetadata _metadata; // Metadata
-        FILE * _fp; // File pointer
+        MmapMetadata metadata_; // Metadata
+        FILE* fp_; // File pointer
 
         /* Save metadata to end of file after all data blocks have been saveed.
          * Also, file pointer is closed at the end.
          */
-        void _finalize() {
-            _metadata.save(_fp);
-            if (fclose(_fp) != 0) {
-                throw std::runtime_error("MmapFileSave: Close file failed.");
+        void finalize_() {
+            metadata_.save(fp_);
+            if (fclose(fp_) != 0) {
+                throw std::runtime_error("MmapStoreSave: Close file failed.");
             }
         }
-}; // end class MmapFileSave
+}; // end class MmapStoreSave
 
-} // end namespace _details
+} // end namespace details_
+
 
 /*
- * Wrapper of _details::_MmapFileSave and _details::_MmapFileLoad to facilitate usage
+ * Wrapper of details_::MmapStoreSave and details_::MmapStoreLoad to facilitate usage
  */
-class MmapFile {
+class MmapStore {
     public:
         // Disable copy/move for single ownership semantics
-        MmapFile(const MmapFile&) = delete;
-        MmapFile(MmapFile&&);
-        MmapFile& operator=(const MmapFile&) = delete;
-        MmapFile& operator=(MmapFile&&);
+        MmapStore(const MmapStore&) = delete;
+        MmapStore(MmapStore&&);
+        MmapStore& operator=(const MmapStore&) = delete;
+        MmapStore& operator=(MmapStore&&);
 
         /* Dummy Constructor */
-        MmapFile() { }
+        MmapStore() { }
         /* Destructor to delete any existing instance */
-        ~MmapFile() { close(); }
+        ~MmapStore() { close(); }
 
         /* Open a filename with given mode read/write and options
          * Parameters:
          *      file_name (string): Path of the file
-         *      mode_str (string): Open for read ("r"), read with pre-fault all pages ("rp"), or for write("w")
+         *      mode_str (string): Open for following options:
+         *          * read ("r") : pre-fault all pages
+         *          * read with lazy load ("r_lazy") : only create mmap, loading when accessing
+         *          * write ("w")
          */
-        void open(const std::string & file_name, const std::string & mode_str) {
-            if (_mode != _Mode::UNINIT) {
+        void open(const std::string& file_name, const std::string& mode_str) {
+            if (mode_ != Mode::UNINIT) {
                 throw std::runtime_error("Should close existing file before open new one.");
             }
-            if (mode_str == "r") {
-                _mmap_r = new _details::_MmapFileLoad(file_name, false);
-                _mode = _Mode::READONLY;
-            }
-            else if (mode_str == "rp") { // pre-load all pages
-                _mmap_r = new _details::_MmapFileLoad(file_name, true);
-                _mode = _Mode::READONLY;
-            }
-            else if (mode_str == "w") {
-                _mmap_w = new _details::_MmapFileSave(file_name);
-                _mode = _Mode::WRITEONLY;
-            }
-            else {
-                throw std::runtime_error("Unrecogonized mode. Should be either 'r' or 'w'.");
+            if (mode_str == "r") { // pre-load all pages
+                mmap_r_ = new details_::MmapStoreLoad(file_name, true);
+                mode_ = Mode::READONLY;
+            } else if (mode_str == "r_lazy") {
+                mmap_r_ = new details_::MmapStoreLoad(file_name, false);
+                mode_ = Mode::READONLY;
+            } else if (mode_str == "w") {
+                mmap_w_ = new details_::MmapStoreSave(file_name);
+                mode_ = Mode::WRITEONLY;
+            } else {
+                throw std::runtime_error("Unrecogonized mode. Should be either 'r', 'r_lazy' or 'w'.");
             }
         }
 
@@ -373,131 +385,165 @@ class MmapFile {
          * If open for read, should NOT close until the data of the file is not visited anymore.
          */
         void close() {
-            if (_mode == _Mode::UNINIT) {
+            if (mode_ == Mode::UNINIT) {
                 return;
+            } else if (mode_ == Mode::READONLY) {
+                delete mmap_r_;
+                mmap_r_ = nullptr;
+            } else if (mode_ == Mode::WRITEONLY) {
+                delete mmap_w_;
+                mmap_w_ = nullptr;
             }
-            else if (_mode == _Mode::READONLY) {
-                delete _mmap_r;
-                _mmap_r = nullptr;
-            }
-            else if (_mode == _Mode::WRITEONLY) {
-                delete _mmap_w;
-                _mmap_w = nullptr;
-            }
-            _mode = _Mode::UNINIT;
+            mode_ = Mode::UNINIT;
         }
 
         /* Expose get/put functions */
-        template<class T>
+        template<class T, class TT=T, details_::if_simple_serializable<TT> = true>
         T fget_one() {
-            _check_get();
-            return _mmap_r->fget_one<T>();
+            check_get_();
+            return mmap_r_->fget_one<T>();
         }
 
-        template<class T>
+        template<class T, class TT=T, details_::if_simple_serializable<TT> = true>
         T* fget_multiple(const uint64_t n_elements) {
-            _check_get();
-            return _mmap_r->fget_multiple<T>(n_elements);
+            check_get_();
+            return mmap_r_->fget_multiple<T>(n_elements);
         }
 
-        template<class T>
+        template<class T, class TT=T, details_::if_simple_serializable<TT> = true>
         void fput_one(const T& src) {
-            _check_put();
-            _mmap_w->fput_one<T>(src);
+            check_put_();
+            mmap_w_->fput_one<T>(src);
         }
 
-        template<class T>
-        void fput_multiple(const T * src, const uint64_t n_elements) {
-            _check_put();
-            _mmap_w->fput_multiple<T>(src, n_elements);
+        template<class T, class TT=T, details_::if_simple_serializable<TT> = true>
+        void fput_multiple(const T* src, const uint64_t n_elements) {
+            check_put_();
+            mmap_w_->fput_multiple<T>(src, n_elements);
         }
 
     private:
-        enum class _Mode {
+        enum class Mode {
             UNINIT = 0,             // Uninitialized
             READONLY = 1,           // "r"
             WRITEONLY = 2,          // "w"
         };
 
-        _details::_MmapFileSave * _mmap_w = nullptr; // Used for write mode
-        _details::_MmapFileLoad * _mmap_r = nullptr; // Used for read mode
-        _Mode _mode = _Mode::UNINIT; // Indicator for current opened mode
+        details_::MmapStoreSave* mmap_w_ = nullptr; // Used for write mode
+        details_::MmapStoreLoad* mmap_r_ = nullptr; // Used for read mode
+        Mode mode_ = Mode::UNINIT; // Indicator for current opened mode
 
         /* Check if opened as read mode for calling get functions */
-        void _check_get() {
-            if (!_mmap_r) {
+        void check_get_() {
+            if (!mmap_r_) {
                 throw std::runtime_error("Not opened for read mode, cannot call get.");
             }
         }
 
         /* Check if opened as write mode for calling put functions */
-        void _check_put() {
-            if (!_mmap_w) {
+        void check_put_() {
+            if (!mmap_w_) {
                 throw std::runtime_error("Not opened for write mode, cannot call put.");
             }
         }
-}; // end class MmapFile
+}; // end class MmapStore
 
 
 /* Extended Vector class that can be used as a std::vector or as a memory-view from part of mmap file
  * For std::vector case, it own the memory for data storage.
- * For mmap view case, it does not own any memory, but serve as a view for a piece of memory owned by MmapFile.
+ * For mmap view case, it does not own any memory, but serve as a view for a piece of memory owned by MmapStore.
  * By default, it is initialized as empty std::vector that can be resized or loaded as mmap view.
  * Once loaded as mmap view, it cannot go back to std::vector case unless clear() is called.
  */
-template<class T, class TT = T, _details::if_simple_serializable<TT> = true>
+template<class T, class TT = T, details_::if_simple_serializable<TT> = true>
 class MmapableVector {
     public:
-        MmapableVector(uint64_t size=0) { resize(size); }
+        /* Constructor */
+        MmapableVector(uint64_t size=0, const T& value=T()) { resize(size, value); }
+
+        /* Copy constructor and assignment */
+        MmapableVector(const MmapableVector<T>& other): size_(other.size_), data_(other.data_) {
+            if (other.is_self_allocated_()) { // non-empty vector
+                store_ = other.store_;
+                data_ = store_.data();
+            }
+        }
+
+        MmapableVector& operator=(const MmapableVector<T>& other) {
+            if(this != &other) {
+                MmapableVector temp(other);
+                swap_(*this, temp);
+            }
+            return *this;
+        }
+
+        /* Move Constructor and Assignment */
+        MmapableVector(MmapableVector<T>&& other): MmapableVector() {
+            swap_(*this, other);
+        }
+
+        MmapableVector& operator=(MmapableVector<T>&& other) {
+            swap_(*this, other);
+            return *this;
+        }
 
         /* Functions to match std::vector interface */
-        uint64_t size() const { return _size; }
+        uint64_t size() const { return size_; }
 
-        const T* data() const { return _data; }
+        T* data() { return data_; }
+        const T* data() const { return data_; }
 
-        T& operator[](uint64_t idx) { return _data[idx]; }
-        const T& operator[](uint64_t idx) const { return _data[idx]; }
+        T& operator[](uint64_t idx) { return data_[idx]; }
+        const T& operator[](uint64_t idx) const { return data_[idx]; }
 
-        bool empty() const { return static_cast<bool> (_size == 0); }
+        bool empty() const { return static_cast<bool> (size_ == 0); }
 
-        void resize(uint64_t new_size) {
-            if(empty() || _is_self_allocated()) { // Valid for empty or self-allocated vector
-                _store.resize(new_size);
-                _data = _store.data();
-                _size = _store.size();
-            }
-            else { // raises error for mmap view
+        void resize(uint64_t size, const T& value=T()) {
+            if(empty() || is_self_allocated_()) { // Valid for empty or self-allocated vector
+                store_.resize(size, value);
+                data_ = store_.data();
+                size_ = store_.size();
+            } else { // raises error for mmap view
                 throw std::runtime_error("Cannot resize for mmap view case.");
             }
         }
 
         void clear() { // Clear any storage
-            _size = 0;
-            _data = nullptr;
-            _store.clear();
+            size_ = 0;
+            data_ = nullptr;
+            store_.clear();
         }
 
-        /* Mmap save & load with MmapFile */
-        void save_mmap(MmapFile & mmap_f) const {
-            mmap_f.fput_one<uint64_t>(_size);
-            mmap_f.fput_multiple<T>(_data, _size);
+        /* Mmap save/load with MmapStore */
+        void save_to_mmap_store(MmapStore& mmap_s) const {
+            mmap_s.fput_one<uint64_t>(size_);
+            mmap_s.fput_multiple<T>(data_, size_);
         }
 
-        void load_mmap(MmapFile & mmap_f) {
-            clear(); // Clean any previous storage
-            _size = mmap_f.fget_one<uint64_t>();
-            _data = mmap_f.fget_multiple<T>(_size);
+        void load_from_mmap_store(MmapStore& mmap_s) {
+            if (is_self_allocated_()) { // raises error for non-empty vector
+                throw std::runtime_error("Cannot load for non-empty vector case.");
+            }
+            size_ = mmap_s.fget_one<uint64_t>();
+            data_ = mmap_s.fget_multiple<T>(size_);
         }
 
     private:
-        uint64_t _size = 0; // Number of elements of the data
-        T* _data = nullptr; // Pointer to actual data
-        std::vector<T> _store; // Actual data storage for self-allocated case
+        uint64_t size_ = 0; // Number of elements of the data
+        T* data_ = nullptr; // Pointer to actual data
+        std::vector<T> store_; // Actual data storage for self-allocated case
 
-        /* Whether data storage is non-empty self-allocated.
-         * True indicates non-empty vector; False indicates either empty or mmap view. */
-        bool _is_self_allocated() const {
-            return static_cast<bool> (_size != 0 && _data == _store.data());
+        /* Whether data storage is non-empty self-allocated vector.
+         * True indicates non-empty vector case; False indicates either empty or mmap view. */
+        bool is_self_allocated_() const {
+            return (!empty() && static_cast<bool> (data_ == store_.data()));
+        }
+
+        /* Swap function for copy and move assignments */
+        void swap_(MmapableVector& lhs, MmapableVector& rhs) {
+            std::swap(lhs.size_, rhs.size_);
+            std::swap(lhs.data_, rhs.data_);
+            std::swap(lhs.store_, rhs.store_);
         }
 
 }; // end class MmapableVector

--- a/pecos/core/utils/mmap_util.hpp
+++ b/pecos/core/utils/mmap_util.hpp
@@ -1,0 +1,509 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+#ifndef __MMAP_UTIL_H__
+#define __MMAP_UTIL_H__
+
+/* Memory-mapped module version.
+ * Must be incremented by 1 everytime when non-backward-compatible change is made. */
+#define __MMAP_UTIL_VER 1
+
+
+#include <cstring>
+#include <fcntl.h>
+#include <memory>
+#include <stdexcept>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <vector>
+#include <string>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include "file_util.hpp"
+
+
+namespace pecos {
+
+namespace mmap_util {
+
+namespace _details { // namespace for Module Private classes
+
+/* Type constraint for mmap save/load.
+ * Please beware, this is only a minimum requirement and not a guarantee that the type is platform-portable for mmap.
+ * If the class/struct members need padding, please double-check mmap file portability on your own. */
+template<class Type>
+constexpr bool IsPlainOldData = std::is_trivially_copyable<Type>::value && std::is_standard_layout<Type>::value;
+
+template<typename Type, typename Ret=bool>
+using if_simple_serializable = std::enable_if_t<IsPlainOldData<Type>, Ret>;
+
+
+/*
+ * Module Private Class to store signature and metadata of all data blocks in mainbody for a memory-mapped file.
+ */
+class _MmapFileMetadata {
+    public:
+        struct MetaInfo{
+            uint64_t offset; // Starting position of each block in the file
+            uint64_t size; // Number of bytes of each block's data
+            MetaInfo(uint64_t offset=0, uint64_t size=0) : offset(offset), size(size) {}
+        };
+
+        /* Save metadata to file.
+         * Parameters:
+         *      fp (FILE *) : File pointer.
+         *          Must points to the end of an opened file and waits for dumping metadata.
+         */
+        void save(FILE * fp) const {
+            uint64_t meta_offset = static_cast<uint64_t>(ftell(fp)); // Record metadata offset
+            _Signature sig = _Signature(meta_offset);
+
+            file_util::fput_one<uint64_t>(_info.size(), fp);
+            file_util::fput_multiple<MetaInfo>(_info.data(), _info.size(), fp);
+
+            sig.save(fp);
+        }
+
+        /* Load metadata from file.
+         * Parameters:
+         *      fp (FILE *) : File pointer.
+         *          Load signature first, then rewind to load metadata.
+         */
+        void load(FILE * fp) {
+            _Signature sig;
+            sig.load(fp);
+
+            fseek(fp, sig.meta_offset, SEEK_SET); // Rewind fp for loading metadata
+            uint64_t n_block = file_util::fget_one<uint64_t>(fp);
+            _info.resize(n_block);
+            file_util::fget_multiple<MetaInfo>(_info.data(), n_block, fp);
+        }
+
+        /* Append a new block's metadata with starting position aligned to at least multiple of sizeof(int)
+         * Parameters:
+         *      size (uint64_t): Number of bytes for the new block's data.
+         * Return:
+         *      n_bytes_to_pad (uint64_t): Number of bytes to pad before saving the new block.
+         */
+        uint64_t aligned_append(const uint64_t size) {
+            const uint64_t align_bytes = 16; // All blocks are aligned to multiple of the value
+
+            uint64_t last_end = 0;
+            if (_info.size() > 0) {
+                auto last_info = _info.back();
+                last_end = last_info.offset + last_info.size;
+            }
+
+            uint64_t n_bytes_to_pad = (align_bytes - (last_end % align_bytes)) % align_bytes;
+            _info.emplace_back(last_end + n_bytes_to_pad, size);
+
+            return n_bytes_to_pad;
+        }
+
+        /* Iterator for retrieving next block's offset/size and auto advance */
+        MetaInfo next() {
+            auto cur_iter = _iter;
+            _iter += 1;
+            return MetaInfo(_info[cur_iter].offset, _info[cur_iter].size);
+        }
+
+    private:
+        /* Struct to store signature for various configuration info of a memory-mapped file */
+        struct _Signature {
+            const uint8_t SIG_SIZE = 16u;                              // Size of signature is 16 bytes
+            // Signture data
+            const uint8_t MAGIC[6] = {0x93u, 'P', 'E', 'C', 'O', 'S'}; // 6 bytes
+            uint8_t endianness;                                        // 1 bytes
+            const uint8_t version = __MMAP_UTIL_VER;                   // 1 bytes
+            uint64_t meta_offset;                                      // 8 bytes
+
+            _Signature(uint64_t meta_offset=0) : endianness(get_endianess()), meta_offset(meta_offset) {}
+
+            /* Save signature to file.
+             * Signature must be saved at the end of file,
+             * i.e. save when everything else has already been saved. */
+            void save(FILE *fp) const {
+                file_util::fput_multiple<uint8_t>(&MAGIC[0], sizeof(MAGIC), fp);
+                file_util::fput_one<uint8_t>(endianness, fp);
+                file_util::fput_one<uint8_t>(version, fp);
+                file_util::fput_one<uint64_t>(meta_offset, fp);
+            }
+
+            /* Load signature from last `SIG_SIZE` bytes of file. */
+            void load(FILE *fp) {
+                // Seek last `SIG_SIZE` bytes
+                fseek(fp, 0 - static_cast<long>(SIG_SIZE), SEEK_END);
+                // Check MAGIC
+                uint8_t loaded_magic[sizeof(MAGIC)];
+                file_util::fget_multiple<uint8_t>(&loaded_magic[0], sizeof(MAGIC), fp);
+                if(std::memcmp(&MAGIC[0], &loaded_magic[0], sizeof(MAGIC)) != 0) {
+                    throw std::runtime_error("File is not a valid PECOS MMAP file");
+                }
+                // Check endianness
+                uint8_t loaded_endianness = file_util::fget_one<uint8_t>(fp);
+                if(loaded_endianness != get_endianess()) {
+                    throw std::runtime_error("Inconsistent endianness between runtime and the mmap file.");
+                }
+                // Check version
+                uint8_t loaded_version = file_util::fget_one<uint8_t>(fp);
+                if (loaded_version != version) {
+                    throw std::runtime_error("Inconsistent version between code and the mmap file.");
+                }
+                // Load meta offset
+                meta_offset = file_util::fget_one<uint64_t>(fp);
+            }
+
+            /* Obtain current machine endianness */
+            uint8_t get_endianess() const {
+                return static_cast<uint8_t>(file_util::runtime());
+            }
+        };
+
+        std::vector<MetaInfo> _info; // offset and size of each block in the file
+        uint64_t _iter = 0; // Iterator index for retrieving metadata info in blocks order
+}; // end class _MmapFileMetadata
+
+
+/*
+ * Module Private Class to load data from a memory-mapped file.
+ */
+class _MmapFileLoad {
+    public:
+        /* Constructor loads from memory-mapped file name
+         * Parameters:
+         *      file_name (const std::string &): Name of file to load from.
+         *      pre_load (const bool): Whether to pre-fault all pages into memory before accessing.
+         */
+        _MmapFileLoad(const std::string & file_name, const bool pre_load) {
+            // Load metadata first
+            FILE * fp = fopen(file_name.c_str(), "rb");
+            if (!fp) {
+                throw std::runtime_error("Load metadata: Open file failed.");
+            }
+            _metadata.load(fp);
+            if (fclose(fp) != 0) {
+                throw std::runtime_error("Load metadata: Close file failed.");
+            }
+
+            // Load mmap
+            int fd = open(file_name.c_str(), O_RDONLY);
+            if (fd == -1) {
+                throw std::runtime_error("Load Mmap file: Open file failed.");
+            }
+            _load_mmap(fd, pre_load);
+            if (close(fd) < 0) {
+                throw std::runtime_error("Load Mmap file: Close file failed.");
+            }
+        }
+        /* Destructor frees the memory-mapped region */
+        ~_MmapFileLoad() { _free_mmap(); }
+
+        /* Load a simple-serializable vector(array)
+         * Parameters:
+         *      n_elements (uint64_t): Number of elements to load for the array.
+         */
+        template<class T, class TT=T, if_simple_serializable<TT> = true>
+        T * fget_multiple(uint64_t n_elements) {
+            auto meta_info = _metadata.next();
+
+            // Verification
+            if (n_elements * static_cast<uint64_t>(sizeof(T)) != meta_info.size) {
+                throw std::runtime_error(
+                    "This block contains " + std::to_string(meta_info.size) +
+                    " bytes data, retrieving " + std::to_string(n_elements * static_cast<uint64_t>(sizeof(T))) +
+                    " bytes not equal. Please double check.");
+            }
+
+            return reinterpret_cast< T * >(reinterpret_cast< char * >(_mmap_ptr) + meta_info.offset);
+        }
+
+        /* Load one element */
+        template<class T>
+        T fget_one() { // Call fget_multiple
+            return * fget_multiple<T>(1u);
+        }
+
+    private:
+        _MmapFileMetadata _metadata; // Metadata
+        void * _mmap_ptr = nullptr; // Memory-mapped pointer
+        uint64_t _mmap_size = 0;// Memory-mapped file size
+
+        /* Create memory-mapped region */
+        void _load_mmap(const int fd, const bool pre_load) {
+            // Get file size
+            struct stat file_stat;
+            fstat(fd, &file_stat);
+            _mmap_size = file_stat.st_size;
+            if (_mmap_size <= 0) {
+                throw std::runtime_error("Memory mapped file size should be positive, got: " + std::to_string(_mmap_size));
+            }
+
+            // Creat mmap
+            int mmap_flags = MAP_SHARED;
+            if (pre_load) { // pre-fault all pages to load them into memory
+                mmap_flags |= MAP_POPULATE;
+            }
+            _mmap_ptr = mmap(NULL, _mmap_size, PROT_READ, mmap_flags, fd, 0);
+            if (_mmap_ptr == MAP_FAILED) {
+                throw std::runtime_error("Memory map failed.");
+            }
+        }
+
+        /* Free memory-mapped region */
+        void _free_mmap() {
+            if (_mmap_ptr) {
+                auto res = munmap(_mmap_ptr, _mmap_size);
+                if (res == EINVAL) {
+                    throw std::runtime_error("Free memory map failed.");
+                }
+                _mmap_ptr = nullptr;
+                _mmap_size = 0;
+            }
+        }
+}; // end class MmapFileLoad
+
+
+/*
+ * Module Private Class to save a series of data, along with metadata and signature into a memory-mapped file.
+ */
+class _MmapFileSave {
+    public:
+        /* Constructor to open a file and save to given filename */
+        _MmapFileSave(const std::string & file_name) {
+            _fp = fopen(file_name.c_str(), "wb");
+            if (!_fp) {
+                throw std::runtime_error("MmapFileSave: Open file failed.");
+            }
+        }
+
+        /* Destructor to save metadata and close opened file after save */
+        ~_MmapFileSave() { _finalize(); }
+
+        /* Save a simple-serializable vector(array) */
+        template<class T, class TT=T, if_simple_serializable<TT> = true>
+        void fput_multiple(const T * src, const uint64_t n_elements) {
+            auto n_bytes_to_pad = _metadata.aligned_append(sizeof(T) * n_elements);
+
+            // Pad previous block end with dummy bytes
+            const char dummy = '\0';
+            for(auto i = 0u; i < n_bytes_to_pad; i++){
+                file_util::fput_one(dummy, _fp);
+            }
+
+            // Save array
+            file_util::fput_multiple<T>(src, n_elements, _fp);
+        }
+
+        /* Save one element */
+        template<class T>
+        void fput_one(const T& src) { // Call fput_multiple
+            fput_multiple<T>(&src, 1u);
+        }
+
+    private:
+        _MmapFileMetadata _metadata; // Metadata
+        FILE * _fp; // File pointer
+
+        /* Save metadata to end of file after all data blocks have been saveed.
+         * Also, file pointer is closed at the end.
+         */
+        void _finalize() {
+            _metadata.save(_fp);
+            if (fclose(_fp) != 0) {
+                throw std::runtime_error("MmapFileSave: Close file failed.");
+            }
+        }
+}; // end class MmapFileSave
+
+} // end namespace _details
+
+/*
+ * Wrapper of _details::_MmapFileSave and _details::_MmapFileLoad to facilitate usage
+ */
+class MmapFile {
+    public:
+        // Disable copy/move for single ownership semantics
+        MmapFile(const MmapFile&) = delete;
+        MmapFile(MmapFile&&);
+        MmapFile& operator=(const MmapFile&) = delete;
+        MmapFile& operator=(MmapFile&&);
+
+        /* Dummy Constructor */
+        MmapFile() { }
+        /* Destructor to delete any existing instance */
+        ~MmapFile() { close(); }
+
+        /* Open a filename with given mode read/write and options
+         * Parameters:
+         *      file_name (string): Path of the file
+         *      mode_str (string): Open for read ("r"), read with pre-fault all pages ("rp"), or for write("w")
+         */
+        void open(const std::string & file_name, const std::string & mode_str) {
+            if (_mode != _Mode::UNINIT) {
+                throw std::runtime_error("Should close existing file before open new one.");
+            }
+            if (mode_str == "r") {
+                _mmap_r = new _details::_MmapFileLoad(file_name, false);
+                _mode = _Mode::READONLY;
+            }
+            else if (mode_str == "rp") { // pre-load all pages
+                _mmap_r = new _details::_MmapFileLoad(file_name, true);
+                _mode = _Mode::READONLY;
+            }
+            else if (mode_str == "w") {
+                _mmap_w = new _details::_MmapFileSave(file_name);
+                _mode = _Mode::WRITEONLY;
+            }
+            else {
+                throw std::runtime_error("Unrecogonized mode. Should be either 'r' or 'w'.");
+            }
+        }
+
+        /* Close any opened files
+         * If open for read, should NOT close until the data of the file is not visited anymore.
+         */
+        void close() {
+            if (_mode == _Mode::UNINIT) {
+                return;
+            }
+            else if (_mode == _Mode::READONLY) {
+                delete _mmap_r;
+                _mmap_r = nullptr;
+            }
+            else if (_mode == _Mode::WRITEONLY) {
+                delete _mmap_w;
+                _mmap_w = nullptr;
+            }
+            _mode = _Mode::UNINIT;
+        }
+
+        /* Expose get/put functions */
+        template<class T>
+        T fget_one() {
+            _check_get();
+            return _mmap_r->fget_one<T>();
+        }
+
+        template<class T>
+        T* fget_multiple(const uint64_t n_elements) {
+            _check_get();
+            return _mmap_r->fget_multiple<T>(n_elements);
+        }
+
+        template<class T>
+        void fput_one(const T& src) {
+            _check_put();
+            _mmap_w->fput_one<T>(src);
+        }
+
+        template<class T>
+        void fput_multiple(const T * src, const uint64_t n_elements) {
+            _check_put();
+            _mmap_w->fput_multiple<T>(src, n_elements);
+        }
+
+    private:
+        enum class _Mode {
+            UNINIT = 0,             // Uninitialized
+            READONLY = 1,           // "r"
+            WRITEONLY = 2,          // "w"
+        };
+
+        _details::_MmapFileSave * _mmap_w = nullptr; // Used for write mode
+        _details::_MmapFileLoad * _mmap_r = nullptr; // Used for read mode
+        _Mode _mode = _Mode::UNINIT; // Indicator for current opened mode
+
+        /* Check if opened as read mode for calling get functions */
+        void _check_get() {
+            if (!_mmap_r) {
+                throw std::runtime_error("Not opened for read mode, cannot call get.");
+            }
+        }
+
+        /* Check if opened as write mode for calling put functions */
+        void _check_put() {
+            if (!_mmap_w) {
+                throw std::runtime_error("Not opened for write mode, cannot call put.");
+            }
+        }
+}; // end class MmapFile
+
+
+/* Extended Vector class that can be used as a std::vector or as a memory-view from part of mmap file
+ * For std::vector case, it own the memory for data storage.
+ * For mmap view case, it does not own any memory, but serve as a view for a piece of memory owned by MmapFile.
+ * By default, it is initialized as empty std::vector that can be resized or loaded as mmap view.
+ * Once loaded as mmap view, it cannot go back to std::vector case unless clear() is called.
+ */
+template<class T, class TT = T, _details::if_simple_serializable<TT> = true>
+class MmapableVector {
+    public:
+        MmapableVector(uint64_t size=0) { resize(size); }
+
+        /* Functions to match std::vector interface */
+        uint64_t size() const { return _size; }
+
+        const T* data() const { return _data; }
+
+        T& operator[](uint64_t idx) { return _data[idx]; }
+        const T& operator[](uint64_t idx) const { return _data[idx]; }
+
+        bool empty() const { return static_cast<bool> (_size == 0); }
+
+        void resize(uint64_t new_size) {
+            if(empty() || _is_self_allocated()) { // Valid for empty or self-allocated vector
+                _store.resize(new_size);
+                _data = _store.data();
+                _size = _store.size();
+            }
+            else { // raises error for mmap view
+                throw std::runtime_error("Cannot resize for mmap view case.");
+            }
+        }
+
+        void clear() { // Clear any storage
+            _size = 0;
+            _data = nullptr;
+            _store.clear();
+        }
+
+        /* Mmap save & load with MmapFile */
+        void save_mmap(MmapFile & mmap_f) const {
+            mmap_f.fput_one<uint64_t>(_size);
+            mmap_f.fput_multiple<T>(_data, _size);
+        }
+
+        void load_mmap(MmapFile & mmap_f) {
+            clear(); // Clean any previous storage
+            _size = mmap_f.fget_one<uint64_t>();
+            _data = mmap_f.fget_multiple<T>(_size);
+        }
+
+    private:
+        uint64_t _size = 0; // Number of elements of the data
+        T* _data = nullptr; // Pointer to actual data
+        std::vector<T> _store; // Actual data storage for self-allocated case
+
+        /* Whether data storage is non-empty self-allocated.
+         * True indicates non-empty vector; False indicates either empty or mmap view. */
+        bool _is_self_allocated() const {
+            return static_cast<bool> (_size != 0 && _data == _store.data());
+        }
+
+}; // end class MmapableVector
+
+} // end namespace mmap_util
+
+} // end namespace pecos
+
+#endif  // end of __MMAP_UTIL_H__


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Add memory-mapped utilility module.

User could test with below code: Copy it into a file`test_mmap_util.cpp` placed at `pecos/core/util/`, and run:
```
gcc -lm -ldl -lstdc++ -fopenmp -std=c++14 -lgcc -lgomp -O3  -I ./ test_mmap_util.cpp
./a.out
```
Output:
```
Generate a Bar with data:
---Bar---
---Foo---
foo_1: 0 1 2 3 4 5 6 7 8 9 
foo_2: 1
---------
bar: 5 5 5 5 5 
---------
Save Bar into mmap file: ./bar_test_mmap.txt
Load a new Bar from saved mmap file...
Loaded Bar data:
---Bar---
---Foo---
foo_1: 0 1 2 3 4 5 6 7 8 9 
foo_2: 1
---------
bar: 5 5 5 5 5 
---------
```
```
#include <iostream>
#include "mmap_util.hpp"

using namespace pecos::mmap_util;

// Nested class mmap example
// Bar contains a Foo instance
class Foo {
    public:
        Foo() {}
        ~Foo() { foo_1.clear(); }

        void init_data() {
            foo_1.resize(10, 0);
            for (int i=0; i<foo_1.size(); ++i) { foo_1[i] = i; }
            foo_2 = 1.0;
        }

        void print() {
            std::cout << "---Foo---" << std::endl;
            std::cout << "foo_1: ";
            for (int i=0; i<foo_1.size(); ++i) { std::cout << foo_1[i] << " "; }
            std::cout << std::endl;
            std::cout << "foo_2: " << foo_2 << std::endl;
            std::cout << "---------" << std::endl;
        }

        void save_to_mmap_store(MmapStore& mmap_s) const {
            foo_1.save_to_mmap_store(mmap_s);
            mmap_s.fput_one<double>(foo_2);
        }

        void load_from_mmap_store(MmapStore& mmap_s) {
            foo_1.load_from_mmap_store(mmap_s);
            foo_2 = mmap_s.fget_one<double>();
        }

    private:
        MmapableVector<int> foo_1;
        double foo_2;
};

class Bar {
    public:
        Bar() { }
        ~Bar() { bar.clear(); mmap_store.close(); }

        void init_data() {
            foo.init_data();
            bar.resize(5, 0);
            for (int i=0; i<bar.size(); ++i) { bar[i] = 5.0; }
        }

        void print() {
            std::cout << "---Bar---" << std::endl;
            foo.print();
            std::cout << "bar: ";
            for (int i=0; i<bar.size(); ++i) { std::cout << bar[i] << " "; }
            std::cout << std::endl;
            std::cout << "---------" << std::endl;
        }

        void save(const std::string & file_name) const {
            // Create a mmapfile for dump at the most outer layer class
            // You cannot reuse (i.e, close and reopen) mmap_store, since it may hold the data storage
            MmapStore mmap_s = MmapStore();
            mmap_s.open(file_name, "w");

            save_to_mmap_store(mmap_s);

            // Metadata dump and fp closure is automatically done at MmapStore destructor when this function ends
            // You can make it happen earlier with explicitly calling close()
            mmap_s.close();
        }
        void load(const std::string & file_name, const bool pre_load=true) {
            mmap_store.open(file_name, pre_load?"r":"r_lazy");
            load_from_mmap_store(mmap_store);
        }

        void save_to_mmap_store(MmapStore& mmap_s) const {
            foo.save_to_mmap_store(mmap_s);
            bar.save_to_mmap_store(mmap_s);
        }

        void load_from_mmap_store(MmapStore& mmap_s) {
            foo.load_from_mmap_store(mmap_s);
            bar.load_from_mmap_store(mmap_s);
        }

    private:
        Foo foo;
        MmapableVector<double> bar;
        // Mmap Data storage at the most outer layer class
        MmapStore mmap_store;
};


int main() {
    std::string f_name = "./bar_test_mmap.txt";

    std::cout << "Generate a Bar with data:" << std::endl;
    Bar bar;
    bar.init_data();
    bar.print();

    std::cout << "Save Bar into mmap file: " << f_name << std::endl;
    bar.save(f_name);

    std::cout << "Load a new Bar from saved mmap file..." << std::endl;
    Bar new_bar;
    new_bar.load(f_name, "r");

    std::cout << "Loaded Bar data:" << std::endl;
    new_bar.print();

    return 0;
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.