### PR TITLE
Python interface for sampling of hierarchical clustering

### DIFF
--- a/pecos/core/ann/quantizer_impl/common.hpp
+++ b/pecos/core/ann/quantizer_impl/common.hpp
@@ -221,14 +221,13 @@ namespace ann {
 
                 // fit HLT or flat-Kmeans for each sub-space
                 std::vector<index_type> assignments(sub_sample_points);
-                pecos::clustering::Tree hlt(std::log2(num_of_local_centroids));
+                int hlt_depth = std::log2(num_of_local_centroids);
+                pecos::clustering::Tree hlt(hlt_depth);
+                pecos::clustering::ClusteringParam clustering_param(0, hlt_depth, seed, max_iter, threads, 1.0, 1.0, 1.0);
                 hlt.run_clustering<pecos::drm_t, index_type>(
                     Xsub,
-                    0,
-                    seed,
-                    assignments.data(),
-                    max_iter,
-                    threads);
+                    &clustering_param,
+                    assignments.data());
 
                 compute_centroids(Xsub, local_dimension, num_of_local_centroids, assignments.data(),
                     &original_local_codebooks[m * num_of_local_centroids * local_dimension], threads);

--- a/pecos/core/libpecos.cpp
+++ b/pecos/core/libpecos.cpp
@@ -257,15 +257,11 @@ extern "C" {
     #define C_RUN_CLUSTERING(SUFFIX, PY_MAT, C_MAT) \
     void c_run_clustering ## SUFFIX( \
         const PY_MAT* py_mat_ptr, \
-        uint32_t depth, \
-        uint32_t partition_algo, \
-        int seed, \
-        uint32_t max_iter, \
-        int threads, \
+        pecos::clustering::ClusteringParam* param_ptr, \
         uint32_t* label_codes) { \
         C_MAT feat_mat(py_mat_ptr); \
-        pecos::clustering::Tree tree(depth); \
-        tree.run_clustering(feat_mat, partition_algo, seed, label_codes, max_iter, threads); \
+        pecos::clustering::Tree tree(param_ptr->depth); \
+        tree.run_clustering(feat_mat, param_ptr, label_codes); \
     }
     C_RUN_CLUSTERING(_csr_f32, ScipyCsrF32, pecos::csr_t)
     C_RUN_CLUSTERING(_drm_f32, ScipyDrmF32, pecos::drm_t)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Implement python interface for connecting the sampling of hierarchical clustering in clustering.hpp. Also, add a toy python unit test for sampling.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.