### PR TITLE
Remove Ubuntu-18.04, Python3.6 and add Ubuntu-22.04, Python3.10 in Actions

### DIFF
--- a/.github/workflows/build_pypi.yml
+++ b/.github/workflows/build_pypi.yml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 4
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         build_platform: ["manylinux2014_x86_64", "manylinux2014_aarch64"]
 
     runs-on: ubuntu-20.04

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
-        platform: [ubuntu-18.04, ubuntu-20.04]
+        platform: [ubuntu-20.04]
 
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,8 +9,8 @@ jobs:
       max-parallel: 4
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
-        platform: [ubuntu-20.04]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        platform: [ubuntu-20.04, ubuntu-22.04]
 
     runs-on: ${{ matrix.platform }}
 
@@ -38,7 +38,7 @@ jobs:
       max-parallel: 4
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     runs-on: ubuntu-latest
     container: amazonlinux:latest

--- a/.github/workflows/pytest_aarch64.yml
+++ b/.github/workflows/pytest_aarch64.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   Ubuntu-Python-Unit-Test:
-    name: Ubuntu 18.04 Python3.6 Unit Tests
+    name: Ubuntu 20.04 Python3.8 Unit Tests
 
     runs-on: ubuntu-latest
 
@@ -17,18 +17,18 @@ jobs:
         platforms: all
 
     - name: Check QEMU Simulator
-      uses: docker://arm64v8/ubuntu:18.04
+      uses: docker://arm64v8/ubuntu:20.04
       with:
         args: 'uname -a'
 
     - name: Install dependencies and Pytest
-      uses: docker://arm64v8/ubuntu:18.04
+      uses: docker://arm64v8/ubuntu:20.04
       with:
         args: >
           bash -c
           "apt-get update &&
           apt-get install -y build-essential git python3 python3-distutils libopenblas-dev wget &&
-          wget https://bootstrap.pypa.io/pip/3.6/get-pip.py &&
+          wget https://bootstrap.pypa.io/get-pip.py &&
           python3 get-pip.py &&
           python3 -m pip install --upgrade pip &&
           make libpecos VFLAG=-v WARN_AS_ERROR=True &&

--- a/.github/workflows/style_type_check.yml
+++ b/.github/workflows/style_type_check.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: "3.7"
     - name: Install dependencies
       id: install-dep
       run: |


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
According to https://github.com/actions/runner-images/issues/6002, Ubuntu-18.04 is on a deprecation path and will periodically receive brownouts until 4/1/2023 to fully unsupported, we definitely need to remove that from the GitHub runner, and also bump the supported Ubuntu version of PECOS alongside.

However, the newest Ubuntu-22.04 does not have a build-in Python 3.6 version which makes it hard for GitHub-hosted runner to run checks, therefore Python versions are also bumped from 3.6 to 3.10 here for all actions, which will act as pre-checks before the bump of PECOS supported Python versions in the **next release**.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.