### PR TITLE
Memory-mapped XLinear Model

### DIFF
--- a/pecos/core/base.py
+++ b/pecos/core/base.py
@@ -728,20 +728,21 @@ class corelib(object):
     def xlinear_load_mmap(
         self,
         folder,
-        pre_load=False,
+        lazy_load=False,
     ):
         """
         Load xlinear model in read-only mmap mode for prediction.
 
         Args:
             folder (str): The folder path for xlinear model.
-            pre_load (bool): Whether to lazy-load (False) or fully load model (True).
+            lazy_load (bool): Whether to lazy-load, i.e. load when needed(True)
+                or fully load model before returning(False).
 
         Return:
             cmodel (ptr): The pointer to xlinear model.
         """
         cmodel = self.clib_float32.c_xlinear_load_mmap_model_from_disk(
-            c_char_p(folder.encode("utf-8")), c_bool(pre_load)
+            c_char_p(folder.encode("utf-8")), c_bool(lazy_load)
         )
         return cmodel
 

--- a/pecos/core/base.py
+++ b/pecos/core/base.py
@@ -630,6 +630,15 @@ class corelib(object):
             self.clib_float32.c_xlinear_load_model_from_disk_ext, res_list, arg_list
         )
 
+        res_list = c_void_p
+        arg_list = [c_char_p, c_bool]
+        corelib.fillprototype(
+            self.clib_float32.c_xlinear_load_mmap_model_from_disk, res_list, arg_list
+        )
+
+        arg_list = [c_char_p, c_char_p]
+        corelib.fillprototype(self.clib_float32.c_xlinear_compile_mmap_model, None, arg_list)
+
         # c interface for per-layer prediction
         arg_list = [
             POINTER(ScipyCsrF32),
@@ -703,6 +712,38 @@ class corelib(object):
         res_list = c_int
         arg_list = [c_void_p, c_int]
         corelib.fillprototype(self.clib_float32.c_xlinear_get_layer_type, res_list, arg_list)
+
+    def xlinear_compile_mmap_model(self, npz_folder, mmap_folder):
+        """
+        Compile xlinear model from npz format to memory-mapped format
+        for faster loading.
+        Args:
+            npz_folder (str): The source folder path for xlinear npz model.
+            mmap_folder (str): The destination folder path for xlinear mmap model.
+        """
+        self.clib_float32.c_xlinear_compile_mmap_model(
+            c_char_p(npz_folder.encode("utf-8")), c_char_p(mmap_folder.encode("utf-8"))
+        )
+
+    def xlinear_load_mmap(
+        self,
+        folder,
+        pre_load=False,
+    ):
+        """
+        Load xlinear model in read-only mmap mode for prediction.
+
+        Args:
+            folder (str): The folder path for xlinear model.
+            pre_load (bool): Whether to lazy-load (False) or fully load model (True).
+
+        Return:
+            cmodel (ptr): The pointer to xlinear model.
+        """
+        cmodel = self.clib_float32.c_xlinear_load_mmap_model_from_disk(
+            c_char_p(folder.encode("utf-8")), c_bool(pre_load)
+        )
+        return cmodel
 
     def xlinear_load_predict_only(
         self,

--- a/pecos/core/libpecos.cpp
+++ b/pecos/core/libpecos.cpp
@@ -37,8 +37,8 @@ extern "C" {
         return static_cast<void*>(model);
     }
 
-    void* c_xlinear_load_mmap_model_from_disk(const char* model_path, const bool pre_load) {
-        auto model = new pecos::HierarchicalMLModel(model_path, pre_load);
+    void* c_xlinear_load_mmap_model_from_disk(const char* model_path, const bool lazy_load) {
+        auto model = new pecos::HierarchicalMLModel(model_path, lazy_load);
         return static_cast<void*>(model);
     }
 

--- a/pecos/core/libpecos.cpp
+++ b/pecos/core/libpecos.cpp
@@ -37,6 +37,17 @@ extern "C" {
         return static_cast<void*>(model);
     }
 
+    void* c_xlinear_load_mmap_model_from_disk(const char* model_path, const bool pre_load) {
+        auto model = new pecos::HierarchicalMLModel(model_path, pre_load);
+        return static_cast<void*>(model);
+    }
+
+    void c_xlinear_compile_mmap_model(const char* model_path, const char* mmap_model_path) {
+        // Only implemented for bin_search_chunked
+        auto model = new pecos::HierarchicalMLModel(model_path, pecos::layer_type_t::LAYER_TYPE_BINARY_SEARCH_CHUNKED);
+        model->save_mmap(mmap_model_path);
+    }
+
     void c_xlinear_destruct_model(void* ptr) {
         pecos::HierarchicalMLModel* mc = static_cast<pecos::HierarchicalMLModel*>(ptr);
         delete mc;

--- a/pecos/core/utils/matrix.hpp
+++ b/pecos/core/utils/matrix.hpp
@@ -208,6 +208,24 @@ namespace pecos {
             col_idx(py->col_idx),
             val(py->val) { }
 
+        // Save/load mmap
+        // Signature for symmetry, not implemented
+        void save_to_mmap_store(mmap_util::MmapStore& mmap_s) const {
+            throw std::runtime_error("Not implemented yet.");
+        }
+
+        void load_from_mmap_store(mmap_util::MmapStore& mmap_s) {
+            throw std::runtime_error("Not implemented yet.");
+        }
+
+        void save(const std::string& file_name) const {
+            throw std::runtime_error("Not implemented yet.");
+        }
+
+        void load(const std::string& file_name, const bool pre_load) {
+            throw std::runtime_error("Not implemented yet.");
+        }
+
         bool is_empty() const {
             return val == nullptr;
         }
@@ -368,14 +386,14 @@ namespace pecos {
             val = mmap_s.fget_multiple<value_type>(nnz);
         }
 
-        void save(const std::string & file_name) const {
+        void save(const std::string& file_name) const {
             mmap_util::MmapStore mmap_s = mmap_util::MmapStore();
             mmap_s.open(file_name, "w");
             save_to_mmap_store(mmap_s);
             mmap_s.close();
         }
 
-        void load(const std::string & file_name, const bool pre_load) {
+        void load(const std::string& file_name, const bool pre_load) {
             free_underlying_memory(); // Clear any existing memory
             mmap_store_ptr = std::make_shared<mmap_util::MmapStore>(); // Create instance
             mmap_store_ptr->open(file_name, pre_load?"r":"r_lazy");

--- a/pecos/core/utils/matrix.hpp
+++ b/pecos/core/utils/matrix.hpp
@@ -218,11 +218,11 @@ namespace pecos {
             throw std::runtime_error("Not implemented yet.");
         }
 
-        void save(const std::string& file_name) const {
+        void save_mmap(const std::string& file_name) const {
             throw std::runtime_error("Not implemented yet.");
         }
 
-        void load(const std::string& file_name, const bool pre_load) {
+        void load_mmap(const std::string& file_name, const bool pre_load) {
             throw std::runtime_error("Not implemented yet.");
         }
 
@@ -386,14 +386,14 @@ namespace pecos {
             val = mmap_s.fget_multiple<value_type>(nnz);
         }
 
-        void save(const std::string& file_name) const {
+        void save_mmap(const std::string& file_name) const {
             mmap_util::MmapStore mmap_s = mmap_util::MmapStore();
             mmap_s.open(file_name, "w");
             save_to_mmap_store(mmap_s);
             mmap_s.close();
         }
 
-        void load(const std::string& file_name, const bool pre_load) {
+        void load_mmap(const std::string& file_name, const bool pre_load) {
             free_underlying_memory(); // Clear any existing memory
             mmap_store_ptr = std::make_shared<mmap_util::MmapStore>(); // Create instance
             mmap_store_ptr->open(file_name, pre_load?"r":"r_lazy");

--- a/pecos/core/utils/matrix.hpp
+++ b/pecos/core/utils/matrix.hpp
@@ -222,7 +222,7 @@ namespace pecos {
             throw std::runtime_error("Not implemented yet.");
         }
 
-        void load_mmap(const std::string& file_name, const bool pre_load) {
+        void load_mmap(const std::string& file_name, const bool lazy_load) {
             throw std::runtime_error("Not implemented yet.");
         }
 
@@ -393,10 +393,10 @@ namespace pecos {
             mmap_s.close();
         }
 
-        void load_mmap(const std::string& file_name, const bool pre_load) {
+        void load_mmap(const std::string& file_name, const bool lazy_load) {
             free_underlying_memory(); // Clear any existing memory
             mmap_store_ptr = std::make_shared<mmap_util::MmapStore>(); // Create instance
-            mmap_store_ptr->open(file_name, pre_load?"r":"r_lazy");
+            mmap_store_ptr->open(file_name, lazy_load?"r_lazy":"r");
             load_from_mmap_store(*mmap_store_ptr);
         }
 

--- a/pecos/core/utils/matrix.hpp
+++ b/pecos/core/utils/matrix.hpp
@@ -24,6 +24,7 @@
 #include <stdexcept>
 #include <vector>
 
+#include "mmap_util.hpp"
 #include "parallel.hpp"
 #include "scipy_loader.hpp"
 
@@ -74,7 +75,7 @@ extern "C" {
 namespace pecos {
     // ===== Container for sparse-dense vectors =====
     // For sparse vectors computational acceleration
-    template<class IDX_T=uint32_t, class VAL_T=float32_t>    
+    template<class IDX_T=uint32_t, class VAL_T=float32_t>
     struct sdvec_t {
         typedef IDX_T index_type;
         typedef VAL_T value_type;
@@ -326,6 +327,9 @@ namespace pecos {
             value_type *data;
         };
 
+        // mmap
+        std::shared_ptr<mmap_util::MmapStore> mmap_store_ptr = nullptr;
+
         csc_t() :
             rows(0),
             cols(0),
@@ -339,6 +343,44 @@ namespace pecos {
             col_ptr(py->col_ptr),
             row_idx(py->row_idx),
             val(py->val) { }
+
+        // Save/load mmap
+        void save_to_mmap_store(mmap_util::MmapStore& mmap_s) const {
+            auto nnz = get_nnz();
+            // scalars
+            mmap_s.fput_one<index_type>(rows);
+            mmap_s.fput_one<index_type>(cols);
+            mmap_s.fput_one<mem_index_type>(nnz);
+            // arrays
+            mmap_s.fput_multiple<mem_index_type>(col_ptr, cols + 1);
+            mmap_s.fput_multiple<index_type>(row_idx, nnz);
+            mmap_s.fput_multiple<value_type>(val, nnz);
+        }
+
+        void load_from_mmap_store(mmap_util::MmapStore& mmap_s) {
+            // scalars
+            rows = mmap_s.fget_one<index_type>();
+            cols = mmap_s.fget_one<index_type>();
+            auto nnz = mmap_s.fget_one<mem_index_type>();
+            // arrays
+            col_ptr = mmap_s.fget_multiple<mem_index_type>(cols + 1);
+            row_idx = mmap_s.fget_multiple<index_type>(nnz);
+            val = mmap_s.fget_multiple<value_type>(nnz);
+        }
+
+        void save(const std::string & file_name) const {
+            mmap_util::MmapStore mmap_s = mmap_util::MmapStore();
+            mmap_s.open(file_name, "w");
+            save_to_mmap_store(mmap_s);
+            mmap_s.close();
+        }
+
+        void load(const std::string & file_name, const bool pre_load) {
+            free_underlying_memory(); // Clear any existing memory
+            mmap_store_ptr = std::make_shared<mmap_util::MmapStore>(); // Create instance
+            mmap_store_ptr->open(file_name, pre_load?"r":"r_lazy");
+            load_from_mmap_store(*mmap_store_ptr);
+        }
 
         bool is_empty() const {
             return val == nullptr;
@@ -361,18 +403,25 @@ namespace pecos {
         // Every function in the inference code that returns a matrix has allocated memory, and
         // therefore one should call this function to free that memory.
         void free_underlying_memory() {
-            if (col_ptr) {
-                delete[] col_ptr;
-                col_ptr = nullptr;
+            if (mmap_store_ptr) { // mmap case, no need to check and free other pointers
+                mmap_store_ptr.reset(); // decrease reference count
+            } else { // memory case
+                if (col_ptr) {
+                    delete[] col_ptr;
+                }
+                if (row_idx) {
+                    delete[] row_idx;
+                }
+                if (val) {
+                    delete[] val;
+                }
             }
-            if (row_idx) {
-                delete[] row_idx;
-                row_idx = nullptr;
-            }
-            if (val) {
-                delete[] val;
-                val = nullptr;
-            }
+            mmap_store_ptr = nullptr;
+            col_ptr = nullptr;
+            row_idx = nullptr;
+            val = nullptr;
+            rows = 0;
+            cols = 0;
         }
 
         csr_t transpose() const ;
@@ -382,6 +431,9 @@ namespace pecos {
         // This allocates memory, so one should call free_underlying_memory on the copy when
         // one is finished using it.
         csc_t deep_copy() const {
+            if (mmap_store_ptr) {
+                throw std::runtime_error("Cannot deep copy for mmap instance.");
+            }
             mem_index_type nnz = col_ptr[cols];
             csc_t res;
             res.allocate(rows, cols, nnz);
@@ -392,6 +444,9 @@ namespace pecos {
         }
 
         void allocate(index_type rows, index_type cols, mem_index_type nnz) {
+            if (mmap_store_ptr) {
+                throw std::runtime_error("Cannot allocate for mmap instance.");
+            }
             this->rows = rows;
             this->cols = cols;
             col_ptr = new mem_index_type[cols + 1];
@@ -401,6 +456,9 @@ namespace pecos {
 
         // Construct a csc_t object with shape _rows x _cols filled by 1.
         void fill_ones(index_type _rows, index_type _cols) {
+            if (mmap_store_ptr) {
+                throw std::runtime_error("Cannot fill ones for mmap instance.");
+            }
             mem_index_type nnz = (mem_index_type) _rows * _cols;
             this->free_underlying_memory();
             this->allocate(_rows, _cols, nnz);
@@ -670,7 +728,7 @@ namespace pecos {
         float32_t ret = 0;
         for(size_t s = 0; s < x.nnz; s++) {
             auto &idx = x.idx[s];
-            if(y.entries[idx].touched) 
+            if(y.entries[idx].touched)
                 ret += y.entries[idx].val * x.val[s];
         }
         return ret;
@@ -749,7 +807,7 @@ namespace pecos {
         float32_t ret = 0;
         for(size_t s = 0; s < x.nr_touch; s++) {
             auto &idx = x.touched_indices[s];
-            if(y.entries[idx].touched) 
+            if(y.entries[idx].touched)
                 ret += y.entries[idx].val * x.entries[idx].val;
         }
         return static_cast<float32_t>(ret);

--- a/pecos/core/utils/mmap_util.hpp
+++ b/pecos/core/utils/mmap_util.hpp
@@ -528,9 +528,9 @@ class MmapableVector {
             data_ = mmap_s.fget_multiple<T>(size_);
         }
 
-        /* Convert from mmap view into self-allocated vector by copying data.
+        /* Convert (from mmap view) into self-allocated vector by copying data.
          * To be noted, this is only a shallow copy and only good for POD without pointer members. */
-        void mmap_to_vec() {
+        void to_self_alloc_vec() {
             if (!is_self_allocated_()) {
                 store_.resize(size_);
                 for (uint64_t i = 0; i < size_; ++i) {

--- a/pecos/core/xmc/inference.hpp
+++ b/pecos/core/xmc/inference.hpp
@@ -355,7 +355,7 @@ namespace pecos {
                 }
             }
             chunks_row_ptr_.resize(chunks_row_ptr_size);
-            mem_index_type * tmp_row_ptr_ptr = chunks_row_ptr_.data();
+            mem_index_type* tmp_row_ptr_ptr = chunks_row_ptr_.data();
             for (chunk_index_type i=0; i < chunk_count; ++i) {
                 auto& chunk = chunks[i];
                 if (chunk.nnz_rows != 0) {
@@ -476,8 +476,8 @@ namespace pecos {
             }
             chunks_row_idx_.resize(chunks_row_idx_size);
             chunks_row_ptr_.resize(chunks_row_ptr_size);
-            index_type * tmp_row_idx_ptr = chunks_row_idx_.data();
-            mem_index_type * tmp_row_ptr_ptr = chunks_row_ptr_.data();
+            index_type* tmp_row_idx_ptr = chunks_row_idx_.data();
+            mem_index_type* tmp_row_ptr_ptr = chunks_row_ptr_.data();
             for (chunk_index_type i=0; i < chunk_count; ++i) {
                 auto& chunk = chunks[i];
                 if (chunk.nnz_rows != 0) {
@@ -1571,8 +1571,8 @@ namespace pecos {
         // Load npz matrices. These are large data struct contains multiple vectors
         std::string w_npz_path = folderpath + "/W.npz";
         std::string c_npz_path = folderpath + "/C.npz";
-        ScipyCscF32Npz * npz_W = new ScipyCscF32Npz;
-        ScipyCscF32Npz * npz_C = new ScipyCscF32Npz;
+        ScipyCscF32Npz* npz_W = new ScipyCscF32Npz;
+        ScipyCscF32Npz* npz_C = new ScipyCscF32Npz;
         npz_W->load(w_npz_path);
         if ((cur_depth == 0) && (access(c_npz_path.c_str(), F_OK) != 0)) {
             // this is to handle the case where the root layer does not have code saved.
@@ -1716,14 +1716,14 @@ namespace pecos {
                 perm_inv.load_from_mmap_store(mmap_s);
             }
 
-            void save(const std::string & file_name) const {
+            void save(const std::string& file_name) const {
                 mmap_util::MmapStore mmap_s = mmap_util::MmapStore();
                 mmap_s.open(file_name, "w");
                 save_to_mmap_store(mmap_s);
                 mmap_s.close();
             }
 
-            void load(const std::string & file_name, const bool pre_load) {
+            void load(const std::string& file_name, const bool pre_load) {
                 mmap_store.open(file_name, pre_load?"r":"r_lazy");
                 load_from_mmap_store(mmap_store);
             }

--- a/pecos/xmc/xlinear/model.py
+++ b/pecos/xmc/xlinear/model.py
@@ -133,6 +133,22 @@ class XLinearModel(pecos.BaseClass):
         )
         return cls(model)
 
+    @classmethod
+    def compile_mmap_model(cls, npz_folder, mmap_folder):
+        """
+        Compile xlinear model from npz format to memory-mapped format
+        for faster loading and referencing.
+        Args:
+            npz_folder (str): The source folder path for xlinear npz model.
+            mmap_folder (str): The destination folder path for xlinear mmap model.
+        """
+        import shutil
+
+        shutil.copyfile(path.join(npz_folder, "param.json"), path.join(mmap_folder, "param.json"))
+        HierarchicalMLModel.compile_mmap_model(
+            path.join(npz_folder, "ranker"), path.join(mmap_folder, "ranker")
+        )
+
     @property
     def is_predict_only(self):
         """


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
* Memory-mapped PECOS XLinear model
  * Greatly reduce loading time. 
  * Ideal for large models that user want to quickly try a few inferences without waiting for loading full model into memory.
  * Also capable for large model inference that could not be stored in memory.

Usage:
User needs to have a XLinear Model saved on disk (in original `.npz` format), and manually compile into mmap format by calling `compile_mmap_model`:
```
import sys
import pathlib
from pecos.xmc.xlinear.model import XLinearModel


npz_model_path = f"/path/to/xlinear/pecos-models/"
mmap_model_path = f"/path/to/xlinear/mmap-models/"

pathlib.Path(mmap_model_path).mkdir(parents=True, exist_ok=True)
print(f"Compiling mmap model from: {npz_model_path}, will save to : {mmap_model_path}...")
XLinearModel.compile_mmap_model(npz_model_path, mmap_model_path)
print("mmap model saved.")
```
Then user can load the memory-mapped model and do inference:
```
import sys
from pecos.xmc.xlinear.model import XLinearModel


mmap_model_path = f"/path/to/xlinear/mmap-models/"

# Load model
if sys.argv[2] == "--cmmap-lazy":
    print("Loading C/C++ mem map model lazy-loaded...")
    xlm = XLinearModel.load(mmap_model_path, is_predict_only=True, lazy_load=True)
elif sys.argv[2] == "--cmmap":
    print("Loading C/C++ mem map model...")
    xlm = XLinearModel.load(mmap_model_path, is_predict_only=True, lazy_load=False)
else:
    print(f"Wrong option: {sys.argv[2]}")

# Load test data
Xt = XLinearModel.load_feature_matrix(f"/test/data/validation/X.npz")
Yt = XLinearModel.load_label_matrix(f"/test/data/validation/Y.npz")

# Predict
Yt_pred = xlm.predict(Xt)
Yt_pred = Yt_pred.tocsr()
metric = smat_util.Metrics.generate(Yt, Yt_pred, topk=10)
print(metric)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.