### PR TITLE
Fix AWS multi-node batch cdk docker file bug

### DIFF
--- a/aws_infra/multinode_batch_cdk/cdk_constructs/dockerfile/Dockerfile
+++ b/aws_infra/multinode_batch_cdk/cdk_constructs/dockerfile/Dockerfile
@@ -6,10 +6,11 @@ ENV PYTHONDONTWRITEBYTECODE=TRUE
 
 # Fix vulnerability
 RUN yum update -y gnupg2
+RUN yum -y updateinfo && yum -y --security update
 
 # Install dependencies
 RUN yum install -y awscli sudo
-RUN yum install -y openssl openssh-client openssh-server iproute2
+RUN yum install -y openssl openssh-clients openssh-server iproute
 RUN yum install -y python3 python3-devel python3-distutils python3-venv
 RUN yum groupinstall -y 'Development Tools'
 RUN amazon-linux-extras install -y epel

--- a/aws_infra/multinode_batch_cdk/cdk_constructs/dockerfile/scripts/dist-run.sh
+++ b/aws_infra/multinode_batch_cdk/cdk_constructs/dockerfile/scripts/dist-run.sh
@@ -52,12 +52,22 @@ install_deps() {
   fi
 }
 
+get_ip() {
+  local ip=$(/sbin/ip -o -4 addr list eth0 | awk '{print $4}' | cut -d/ -f1)
+  if [[ -z $ip ]]; then
+    echo "Failed to get IP."
+    error_exit
+  else
+    echo "$ip"
+  fi
+}
+
 # wait for all nodes to report
 wait_for_nodes () {
   log "Running as master node"
 
   touch $NODE_IP_FILE_PATH
-  ip=$(/sbin/ip -o -4 addr list eth0 | awk '{print $4}' | cut -d/ -f1)
+  ip=$(get_ip)
 
   if [ -x "$(command -v nvidia-smi)" ] ; then
       NUM_GPUS=$(ls -l /dev/nvidia[0-9] | wc -l)
@@ -132,7 +142,7 @@ wait_for_nodes () {
 report_to_master () {
   # get own ip and num cpus
   #
-  ip=$(/sbin/ip -o -4 addr list eth0 | awk '{print $4}' | cut -d/ -f1)
+  ip=$(get_ip)
 
   if [ -x "$(command -v nvidia-smi)" ] ; then
       NUM_GPUS=$(ls -l /dev/nvidia[0-9] | wc -l)


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Fixed AWS multi-node Batch CDK's dockerfile bug of not installing `iproute2` and `openssl-clients`.
Also added a check for failing to get IP addresses.

Tested with `eurlex-4k` data following https://github.com/amzn/pecos/blob/mainline/aws_infra/multinode_batch_cdk/README.md

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.