### PR TITLE
Remove sphinx_rtd_theme from requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -110,8 +110,7 @@ numpy_requires = [
     'numpy>=1.19.5; python_version>="3.7"'
 ]
 setup_requires = numpy_requires + [
-    'pytest-runner',
-    'sphinx_rtd_theme'
+    'pytest-runner'
 ]
 install_requires = numpy_requires + [
     'scipy>=1.4.1',


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
sphinx_rtd_theme is an unused package for docsite that PECOS does not plan to implement in the near future, and causing setuptool ContextualVersionConflict, therefore removed for now


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.