### PR TITLE
Add make clean in CDK Dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,5 +62,6 @@ test: libpecos
 clean:
 	rm ${VFLAG} -rf ./build ./dist ./*.egg-info
 	rm -f ./pecos/core/*.so .coverage*
+	rm -f ./pecos/_version.py
 	python3 -Bc "import pathlib; [p.unlink() for p in pathlib.Path('.').rglob('*.py[co]')]"
 	python3 -Bc "import pathlib; [p.rmdir() for p in pathlib.Path('.').rglob('__pycache__')]"

--- a/aws_infra/multinode_batch_cdk/cdk_constructs/dockerfile/Dockerfile
+++ b/aws_infra/multinode_batch_cdk/cdk_constructs/dockerfile/Dockerfile
@@ -31,7 +31,7 @@ ADD README.md /pecos-source/README.md
 ADD Makefile /pecos-source/Makefile
 ADD setup.py /pecos-source/setup.py
 ADD pecos /pecos-source/pecos/
-RUN cd /pecos-source && make libpecos
+RUN cd /pecos-source && make clean && make libpecos
 
 # Setup user
 RUN groupadd -r amazon && useradd --no-log-init -r -g amazon ecs-user
@@ -39,7 +39,7 @@ RUN echo "ecs-user ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 ENV USER ecs-user
 ENV HOME /home/$USER
 RUN echo $HOME
-RUN chown -R ecs-user:amazon /home
+RUN mkdir -p $HOME && chown -R ecs-user:amazon $HOME
 
 # Enable password-less SSH
 ENV SSHDIR $HOME/.ssh


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Since CDK now build image from local source, it makes more sense that user does not need to take care to clean up local repository before CDK synth & deploy, instead, docker copies source code folder and cleans before build. This will prevent weird bugs from forgetting to clean up local build, more likely if local/image platform/os have differences.

Not using `.dockerignore` because it would actually be a duplicate of `Makefile` clean items.

Tested with a local build from python3.10 and image build from python3.7 to ensure correctness.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.