### PR TITLE
switch between sdvec and dense vec

### DIFF
--- a/pecos/core/ann/quantizer_impl/common.hpp
+++ b/pecos/core/ann/quantizer_impl/common.hpp
@@ -222,8 +222,11 @@ namespace ann {
                 // fit HLT or flat-Kmeans for each sub-space
                 std::vector<index_type> assignments(sub_sample_points);
                 int hlt_depth = std::log2(num_of_local_centroids);
+                float max_sample_rate = 1.0;
+                float min_sample_rate = 1.0;
+                float warmup_ratio = 1.0;
                 pecos::clustering::Tree hlt(hlt_depth);
-                pecos::clustering::ClusteringParam clustering_param(0, hlt_depth, seed, max_iter, threads, 1.0, 1.0, 1.0);
+                pecos::clustering::ClusteringParam clustering_param(0, seed, max_iter, threads, max_sample_rate, min_sample_rate, warmup_ratio);
                 hlt.run_clustering<pecos::drm_t, index_type>(
                     Xsub,
                     &clustering_param,

--- a/pecos/core/base.py
+++ b/pecos/core/base.py
@@ -155,7 +155,6 @@ class ClusteringParam(ctypes.Structure):
 
     _fields_ = [
         ("partition_algo", c_uint64),
-        ("depth", c_uint64),
         ("seed", c_int),
         ("kmeans_max_iter", c_uint64),
         ("threads", c_int),
@@ -1314,6 +1313,7 @@ class corelib(object):
         """
         arg_list = [
             POINTER(ScipyCsrF32),
+            c_uint64,
             POINTER(ClusteringParam),
             POINTER(c_uint32),
         ]
@@ -1354,9 +1354,11 @@ class corelib(object):
 
         if codes is None or len(codes) != py_feat_mat.shape[0] or codes.dtype != np.uint32:
             codes = np.zeros(py_feat_mat.rows, dtype=np.uint32)
+        depth = train_params.depth
         train_params = ClusteringParam(train_params)
         run_clustering(
             byref(py_feat_mat),
+            depth,
             train_params,
             codes.ctypes.data_as(POINTER(c_uint32)),
         )

--- a/pecos/core/libpecos.cpp
+++ b/pecos/core/libpecos.cpp
@@ -268,10 +268,11 @@ extern "C" {
     #define C_RUN_CLUSTERING(SUFFIX, PY_MAT, C_MAT) \
     void c_run_clustering ## SUFFIX( \
         const PY_MAT* py_mat_ptr, \
+        size_t depth, \
         pecos::clustering::ClusteringParam* param_ptr, \
         uint32_t* label_codes) { \
         C_MAT feat_mat(py_mat_ptr); \
-        pecos::clustering::Tree tree(param_ptr->depth); \
+        pecos::clustering::Tree tree(depth); \
         tree.run_clustering(feat_mat, param_ptr, label_codes); \
     }
     C_RUN_CLUSTERING(_csr_f32, ScipyCsrF32, pecos::csr_t)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Design a strategy to automatically switch between dense vectors and sdvecs that store cluster centers. If the center worst max density is above the threshold, use dense vec, otherwise use sdvec. It brings a 1.5-2x speedup on clustering.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.