### PR TITLE
Update setup.py according to dependences upgrades

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -41,7 +41,7 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     runs-on: ubuntu-latest
-    container: amazonlinux:latest
+    container: amazonlinux:2
 
     steps:
     - uses: actions/checkout@v1

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ install_requires = numpy_requires + [
 ]
 
 # Fetch Numpy before building Numpy-dependent extension, if Numpy required version was not installed
-setuptools.dist.Distribution().fetch_build_eggs(numpy_requires)
+setuptools.distutils.core.Distribution().fetch_build_eggs(numpy_requires)
 blas_lib, blas_dir = BlasHelper.get_blas_lib_dir()
 
 # Get extra manual compile args if any

--- a/setup.py
+++ b/setup.py
@@ -115,7 +115,7 @@ setup_requires = numpy_requires + [
 install_requires = numpy_requires + [
     'scipy>=1.4.1',
     'scikit-learn>=0.24.1',
-    'torch>=1.8.0',
+    'torch>=1.8.0,<2.0.0',
     'sentencepiece>=0.1.86,!=0.1.92', # 0.1.92 results in error for transformers
     'transformers>=4.1.1; python_version<"3.9"',
     'transformers>=4.4.2; python_version>="3.9"'


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
`setuptools` updated  module `setuptools.Distribution` in PEP 517 backend patch to be `distutils.core.Distribution`, and the original is deprecated. Modify `setup.py` usage accordingly.

Pinned AmazonLinux unittest container to `amazonlinux:2` since `amazonlinux:latest` is Amazon Linux 2023 now. We'll upgrade to support for AL2023 in next release.

Added torch<2.0 requirement for the transformers unittests to pass.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.