### PR TITLE
Extend Sparse Inner Products to support DRM2DCM

### DIFF
--- a/pecos/core/base.py
+++ b/pecos/core/base.py
@@ -1173,14 +1173,24 @@ class corelib(object):
             c_int,  # threads
         ]
         corelib.fillprototype(
-            self.clib_float32.c_sparse_inner_products_csr_f32,
+            self.clib_float32.c_sparse_inner_products_csr2csc_f32,
             None,
-            [POINTER(ScipyCsrF32)] + arg_list[1:],
+            [POINTER(ScipyCsrF32), POINTER(ScipyCscF32)] + arg_list[2:],
         )
         corelib.fillprototype(
-            self.clib_float32.c_sparse_inner_products_drm_f32,
+            self.clib_float32.c_sparse_inner_products_drm2csc_f32,
             None,
-            [POINTER(ScipyDrmF32)] + arg_list[1:],
+            [POINTER(ScipyDrmF32), POINTER(ScipyCscF32)] + arg_list[2:],
+        )
+        corelib.fillprototype(
+            self.clib_float32.c_sparse_inner_products_csr2dcm_f32,
+            None,
+            [POINTER(ScipyCsrF32), POINTER(ScipyDcmF32)] + arg_list[2:],
+        )
+        corelib.fillprototype(
+            self.clib_float32.c_sparse_inner_products_drm2dcm_f32,
+            None,
+            [POINTER(ScipyDrmF32), POINTER(ScipyDcmF32)] + arg_list[2:],
         )
 
     def sparse_matmul(self, X, Y, eliminate_zeros=False, sorted_indices=True, threads=-1):
@@ -1259,17 +1269,17 @@ class corelib(object):
 
         return pred_alloc.get()
 
-    def sparse_inner_products(self, pX, pW, X_row_idx, W_col_idx, pred_values=None, threads=-1):
+    def sparse_inner_products(self, X, W, X_row_idx, W_col_idx, pred_values=None, threads=-1):
         """
         Sparse-Sparse matrix batch inner product with multithreading (shared-memory).
         Do inner product for rows from `pX` indicated by `X_row_idx`, and columns from `pW` indicated by `W_col_idx`.
         Results will be written in `pred_values` if provided; Otherwise, create a new array for results.
 
         Args:
-            pX (ScipyCsrF32, ScipyDrmF32): The first sparse matrix.
-            pW (ScipyCscF32, ScipyDcmF32): The second sparse matrix.
-            X_row_idx (ndarray): Row indexes for `pX`.
-            W_col_idx (ndarray): Column indexes for `pW`.
+            X (smat.csr_matrix, or np.ndarray): The first row-majored sparse/dense matrix, w/ dtype of np.float32.
+            W (smat.csc_matrix, or np.ndarray): The second col-majored sparse/dense matrix, w/ dtype of np.float32.
+            X_row_idx (ndarray): Row indexes for `X` matrix, w/ dtype of np.uint32.
+            W_col_idx (ndarray): Column indexes for `W` matrix, w/ dtype of np.uint32.
             pred_values (ndarray, optional): The inner product result array.
             threads (int, optional): The number of threads. Default -1 to use all cores.
 
@@ -1281,16 +1291,24 @@ class corelib(object):
 
         nnz = len(X_row_idx)
         assert nnz == len(W_col_idx)
+        assert X.shape[1] == W.shape[0]
 
-        if not isinstance(pW, ScipyCscF32):
-            raise NotImplementedError("type(pW) = {} no implemented".format(type(pW)))
-
-        if isinstance(pX, ScipyCsrF32):
-            c_sparse_inner_products = clib.c_sparse_inner_products_csr_f32
-        elif isinstance(pX, ScipyDrmF32):
-            c_sparse_inner_products = clib.c_sparse_inner_products_drm_f32
+        if isinstance(X, smat.csr_matrix) and isinstance(W, smat.csc_matrix):
+            pX, pW = ScipyCsrF32.init_from(X), ScipyCscF32.init_from(W)
+            c_sparse_inner_products = clib.c_sparse_inner_products_csr2csc_f32
+        elif isinstance(X, np.ndarray) and isinstance(W, smat.csc_matrix):
+            pX, pW = ScipyDrmF32.init_from(X), ScipyCscF32.init_from(W)
+            c_sparse_inner_products = clib.c_sparse_inner_products_drm2csc_f32
+        elif isinstance(X, smat.csr_matrix) and isinstance(W, np.ndarray):
+            pX, pW = ScipyCsrF32.init_from(X), ScipyDcmF32.init_from(W)
+            c_sparse_inner_products = clib.c_sparse_inner_products_csr2dcm_f32
+        elif isinstance(X, np.ndarray) and isinstance(W, np.ndarray):
+            pX, pW = ScipyDrmF32.init_from(X), ScipyDcmF32.init_from(W)
+            c_sparse_inner_products = clib.c_sparse_inner_products_drm2dcm_f32
         else:
-            raise NotImplementedError("type(pX) = {} no implemented".format(type(pX)))
+            raise NotImplementedError(
+                "type(X)={} and type(W)={} no implemented".format(type(X), type(W))
+            )
 
         if pred_values is None or len(pred_values) != nnz or pred_values.dtype != np.float32:
             pred_values = np.zeros(nnz, pW.dtype)

--- a/pecos/core/libpecos.cpp
+++ b/pecos/core/libpecos.cpp
@@ -245,23 +245,25 @@ extern "C" {
     C_SPARSE_MATMUL(_csr_f32, ScipyCsrF32, pecos::csr_t)
 
 
-    #define C_SPARSE_INNER_PRODUCTS(SUFFIX, PY_MAT, C_MAT) \
+    #define C_SPARSE_INNER_PRODUCTS(SUFFIX, PX_MAT, CX_MAT, PW_MAT, CW_MAT) \
     void c_sparse_inner_products ## SUFFIX( \
-        const PY_MAT *pX, \
-        const ScipyCscF32 *pW, \
+        const PX_MAT *pX, \
+        const PW_MAT *pW, \
         uint64_t len, \
         uint32_t *X_row_idx, \
         uint32_t *W_col_idx, \
         float32_t *val, \
         int threads) { \
-        C_MAT X(pX); \
-        pecos::csc_t W(pW); \
+        CX_MAT X(pX); \
+        CW_MAT W(pW); \
         compute_sparse_entries_from_rowmajored_X_and_colmajored_M( \
             X, W, len, X_row_idx, W_col_idx, val, threads \
         ); \
     }
-    C_SPARSE_INNER_PRODUCTS(_csr_f32, ScipyCsrF32, pecos::csr_t)
-    C_SPARSE_INNER_PRODUCTS(_drm_f32, ScipyDrmF32, pecos::drm_t)
+    C_SPARSE_INNER_PRODUCTS(_csr2csc_f32, ScipyCsrF32, pecos::csr_t, ScipyCscF32, pecos::csc_t)
+    C_SPARSE_INNER_PRODUCTS(_drm2csc_f32, ScipyDrmF32, pecos::drm_t, ScipyCscF32, pecos::csc_t)
+    C_SPARSE_INNER_PRODUCTS(_csr2dcm_f32, ScipyCsrF32, pecos::csr_t, ScipyDcmF32, pecos::dcm_t)
+    C_SPARSE_INNER_PRODUCTS(_drm2dcm_f32, ScipyDrmF32, pecos::drm_t, ScipyDcmF32, pecos::dcm_t)
 
     // ==== C Interface of Clustering ====
 

--- a/test/pecos/core/test_clib.py
+++ b/test/pecos/core/test_clib.py
@@ -1,0 +1,69 @@
+#  Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+#  with the License. A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0/
+#
+#  or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+#  OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+#  and limitations under the License.
+import pytest  # noqa: F401; pylint: disable=unused-variable
+from pytest import approx
+
+
+def test_importable():
+    import pecos.core  # noqa: F401
+    from pecos.core import clib  # noqa: F401
+
+
+def test_smat_matmul():
+    import numpy as np
+    import scipy.sparse as smat
+    from pecos.core import clib
+
+    X = smat.csr_matrix([[1.0, 0.0], [0.5, 0.5], [0.0, 1.0]], dtype=np.float32)
+    Y = smat.csr_matrix([[0.5, 0.0], [0.0, 1.0], [1.0, 0.0], [0.0, 0.5]], dtype=np.float32)
+    gt_XYT = np.array(
+        [[0.50, 0.00, 1.00, 0.00], [0.25, 0.50, 0.50, 0.25], [0.00, 1.00, 0.00, 0.50]],
+        dtype=np.float32,
+    )
+
+    pd_XYT = clib.sparse_matmul(X, Y.T, threads=2).toarray()
+
+    assert gt_XYT == approx(
+        pd_XYT, abs=1e-9
+    ), f"gt_XYT (true matmul) != pd_XYT (our pecos.sparse_matmul), where X/Y are sparse"
+
+
+def test_sparse_inner_products():
+    import numpy as np
+    import scipy.sparse as smat
+    from pecos.core import clib
+
+    X = smat.csr_matrix([[1.0, 0.0], [0.5, 0.5], [0.0, 1.0]], dtype=np.float32)
+    Y = smat.csr_matrix([[0.5, 0.0], [0.0, 1.0], [1.0, 0.0], [0.0, 0.5]], dtype=np.float32)
+    gt_XYT = np.array(
+        [[0.50, 0.00, 1.00, 0.00], [0.25, 0.50, 0.50, 0.25], [0.00, 1.00, 0.00, 0.50]],
+        dtype=np.float32,
+    )
+    X_row_idx = np.array([0, 1, 2], dtype=np.uint32)
+    Y_col_idx = np.array([1, 2, 3], dtype=np.uint32)
+    true_vals = np.array(
+        [gt_XYT[i, j] for i, j in zip(X_row_idx, Y_col_idx)],
+        dtype=np.float32,
+    )
+
+    # test csr2csc
+    pred_vals = clib.sparse_inner_products(X, Y.T, X_row_idx, Y_col_idx)
+    assert true_vals == approx(
+        pred_vals, abs=1e-9
+    ), f"true_vals != pred_vals, where X/Y are csr/csc"
+
+    # test drm2dcm
+    X_dense = X.toarray()
+    Y_dense = Y.toarray()
+    pred_vals = clib.sparse_inner_products(X_dense, Y_dense.T, X_row_idx, Y_col_idx)
+    assert true_vals == approx(
+        pred_vals, abs=1e-9
+    ), f"true_vals != pred_vals, where X/Y are drm/dcm"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
(1) support `sparse_inner_products` with both sparse and dense matrix type.
- `csr x csc`
- `drm x csc`
- `csr x dcm`
- `drm x dcm`

(2) Also add unit tests for `sparse_inner_products` and `sparse_matmul` in `pecos.core.clib`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.