### PR TITLE
Add mmap value store for multi-thread fast retrieval of 2D sub-matrix

### DIFF
--- a/pecos/core/base.py
+++ b/pecos/core/base.py
@@ -1861,7 +1861,62 @@ class corelib(object):
         """
         Specify C-lib's numerical Memory-mappable value store methods arguments and return types.
         """
-        return {}
+        fn_prefix = "mmap_valstore"
+        store_type = "str"
+
+        local_fn_dict = {}
+
+        fn_name = "new"
+        local_fn_dict[fn_name] = getattr(self.clib_float32, f"{fn_prefix}_{fn_name}_{store_type}")
+        corelib.fillprototype(local_fn_dict[fn_name], c_void_p, None)
+
+        fn_name = "destruct"
+        local_fn_dict[fn_name] = getattr(self.clib_float32, f"{fn_prefix}_{fn_name}_{store_type}")
+        corelib.fillprototype(local_fn_dict[fn_name], None, [c_void_p])
+
+        fn_name = "n_row"
+        local_fn_dict[fn_name] = getattr(self.clib_float32, f"{fn_prefix}_{fn_name}_{store_type}")
+        corelib.fillprototype(local_fn_dict[fn_name], c_uint64, [c_void_p])
+
+        fn_name = "n_col"
+        local_fn_dict[fn_name] = getattr(self.clib_float32, f"{fn_prefix}_{fn_name}_{store_type}")
+        corelib.fillprototype(local_fn_dict[fn_name], c_uint32, [c_void_p])
+
+        fn_name = "save"
+        local_fn_dict[fn_name] = getattr(self.clib_float32, f"{fn_prefix}_{fn_name}_{store_type}")
+        corelib.fillprototype(local_fn_dict[fn_name], None, [c_void_p, c_char_p])
+
+        fn_name = "load"
+        local_fn_dict[fn_name] = getattr(self.clib_float32, f"{fn_prefix}_{fn_name}_{store_type}")
+        corelib.fillprototype(local_fn_dict[fn_name], c_void_p, [c_char_p, c_bool])
+
+        fn_name = "from_vals"
+        local_fn_dict[fn_name] = getattr(self.clib_float32, f"{fn_prefix}_{fn_name}_{store_type}")
+        corelib.fillprototype(
+            local_fn_dict[fn_name],
+            None,
+            [c_void_p, c_uint64, c_uint32, c_void_p, POINTER(c_uint32)],
+        )
+
+        fn_name = "get_submatrix"
+        local_fn_dict[fn_name] = getattr(self.clib_float32, f"{fn_prefix}_{fn_name}_{store_type}")
+        corelib.fillprototype(
+            local_fn_dict[fn_name],
+            None,
+            [
+                c_void_p,
+                c_uint32,  # n_sub_row
+                c_uint32,  # n_sub_col
+                POINTER(c_uint64),  # sub_rows
+                POINTER(c_uint32),  # sub_cols
+                c_uint32,  # trunc_val_len
+                c_char_p,  # ret
+                POINTER(c_uint32),  # ret_lens
+                c_uint32,  # threads
+            ],
+        )
+
+        return local_fn_dict
 
     def link_mmap_valstore_methods(self):
         """
@@ -1870,7 +1925,7 @@ class corelib(object):
 
         self.mmap_valstore_fn_dict = {
             "num_f32": self._get_num_f32_mmap_valstore_methods(),
-            "string": self._get_str_mmap_valstore_methods(),
+            "str": self._get_str_mmap_valstore_methods(),
         }
 
     def mmap_valstore_init(self, store_type):

--- a/pecos/core/base.py
+++ b/pecos/core/base.py
@@ -533,6 +533,7 @@ class corelib(object):
         self.link_tfidf_vectorizer()
         self.link_ann_hnsw_methods()
         self.link_mmap_hashmap_methods()
+        self.link_mmap_valstore_methods()
 
     def link_xlinear_methods(self):
         """
@@ -1798,6 +1799,90 @@ class corelib(object):
         if map_type not in self.mmap_map_fn_dict:
             raise NotImplementedError(f"map_type={map_type} is not implemented.")
         return self.mmap_map_fn_dict[map_type]
+
+    def _get_num_f32_mmap_valstore_methods(self):
+        """
+        Specify C-lib's numerical float32 Memory-mappable store methods arguments and return types.
+        """
+        fn_prefix = "mmap_valstore"
+        store_type = "float32"
+
+        local_fn_dict = {}
+
+        fn_name = "new"
+        local_fn_dict[fn_name] = getattr(self.clib_float32, f"{fn_prefix}_{fn_name}_{store_type}")
+        corelib.fillprototype(local_fn_dict[fn_name], c_void_p, None)
+
+        fn_name = "destruct"
+        local_fn_dict[fn_name] = getattr(self.clib_float32, f"{fn_prefix}_{fn_name}_{store_type}")
+        corelib.fillprototype(local_fn_dict[fn_name], None, [c_void_p])
+
+        fn_name = "n_row"
+        local_fn_dict[fn_name] = getattr(self.clib_float32, f"{fn_prefix}_{fn_name}_{store_type}")
+        corelib.fillprototype(local_fn_dict[fn_name], c_uint64, [c_void_p])
+
+        fn_name = "n_col"
+        local_fn_dict[fn_name] = getattr(self.clib_float32, f"{fn_prefix}_{fn_name}_{store_type}")
+        corelib.fillprototype(local_fn_dict[fn_name], c_uint32, [c_void_p])
+
+        fn_name = "save"
+        local_fn_dict[fn_name] = getattr(self.clib_float32, f"{fn_prefix}_{fn_name}_{store_type}")
+        corelib.fillprototype(local_fn_dict[fn_name], None, [c_void_p, c_char_p])
+
+        fn_name = "load"
+        local_fn_dict[fn_name] = getattr(self.clib_float32, f"{fn_prefix}_{fn_name}_{store_type}")
+        corelib.fillprototype(local_fn_dict[fn_name], c_void_p, [c_char_p, c_bool])
+
+        fn_name = "from_vals"
+        local_fn_dict[fn_name] = getattr(self.clib_float32, f"{fn_prefix}_{fn_name}_{store_type}")
+        corelib.fillprototype(
+            local_fn_dict[fn_name], None, [c_void_p, c_uint64, c_uint32, POINTER(c_float)]
+        )
+
+        fn_name = "get_submatrix"
+        local_fn_dict[fn_name] = getattr(self.clib_float32, f"{fn_prefix}_{fn_name}_{store_type}")
+        corelib.fillprototype(
+            local_fn_dict[fn_name],
+            None,
+            [
+                c_void_p,
+                c_uint32,
+                c_uint32,
+                POINTER(c_uint64),
+                POINTER(c_uint32),
+                POINTER(c_float),
+                c_uint32,
+            ],
+        )
+
+        return local_fn_dict
+
+    def _get_str_mmap_valstore_methods(self):
+        """
+        Specify C-lib's numerical Memory-mappable value store methods arguments and return types.
+        """
+        return {}
+
+    def link_mmap_valstore_methods(self):
+        """
+        Specify C-lib's Memory-mappable value store methods arguments and return types.
+        """
+
+        self.mmap_valstore_fn_dict = {
+            "num_f32": self._get_num_f32_mmap_valstore_methods(),
+            "string": self._get_str_mmap_valstore_methods(),
+        }
+
+    def mmap_valstore_init(self, store_type):
+        """Python to C/C++ interface for Memory-mappable store initialization
+        Args:
+            store_type (string): Type of store.
+        Returns:
+            mmap_valstore_fn_dict (dict): a dictionary that holds clib's C/C++ functions for Python to call
+        """
+        if store_type not in self.mmap_valstore_fn_dict:
+            raise NotImplementedError(f"store_type={store_type} is not implemented.")
+        return self.mmap_valstore_fn_dict[store_type]
 
 
 clib = corelib(os.path.join(os.path.dirname(os.path.abspath(pecos.__file__)), "core"), "libpecos")

--- a/pecos/core/libpecos.cpp
+++ b/pecos/core/libpecos.cpp
@@ -556,6 +556,7 @@ extern "C" {
     // ==== C Interface of Memory-mappable Value Store ====
 
     typedef pecos::mmap_valstore::Float32Store mmap_valstore_float32;
+    typedef pecos::mmap_valstore::StringStore mmap_valstore_str;
     typedef pecos::mmap_valstore::row_type row_type;
     typedef pecos::mmap_valstore::col_type col_type;
 
@@ -564,30 +565,35 @@ extern "C" {
     void* mmap_valstore_new_ ## SUFFIX () { \
     return static_cast<void*>(new mmap_valstore_ ## SUFFIX()); }
     MMAP_VALSTORE_NEW(float32)
+    MMAP_VALSTORE_NEW(str)
 
     // Destruct
     #define MMAP_VALSTORE_DESTRUCT(SUFFIX) \
     void mmap_valstore_destruct_ ## SUFFIX (void* map_ptr) { \
     delete static_cast<mmap_valstore_ ## SUFFIX *>(map_ptr); }
     MMAP_VALSTORE_DESTRUCT(float32)
+    MMAP_VALSTORE_DESTRUCT(str)
 
     // Number of rows
     #define MMAP_MAP_N_ROW(SUFFIX) \
     row_type mmap_valstore_n_row_ ## SUFFIX (void* map_ptr) { \
     return static_cast<mmap_valstore_ ## SUFFIX *>(map_ptr)->n_row(); }
     MMAP_MAP_N_ROW(float32)
+    MMAP_MAP_N_ROW(str)
 
     // Number of columns
     #define MMAP_MAP_N_COL(SUFFIX) \
     col_type mmap_valstore_n_col_ ## SUFFIX (void* map_ptr) { \
     return static_cast<mmap_valstore_ ## SUFFIX *>(map_ptr)->n_col(); }
     MMAP_MAP_N_COL(float32)
+    MMAP_MAP_N_COL(str)
 
     // Save
     #define MMAP_VALSTORE_SAVE(SUFFIX) \
     void mmap_valstore_save_ ## SUFFIX (void* map_ptr, const char* map_dir) { \
     static_cast<mmap_valstore_ ## SUFFIX *>(map_ptr)->save(map_dir); }
     MMAP_VALSTORE_SAVE(float32)
+    MMAP_VALSTORE_SAVE(str)
 
     // Load
     #define MMAP_VALSTORE_LOAD(SUFFIX) \
@@ -596,6 +602,7 @@ extern "C" {
     map_ptr->load(map_dir, lazy_load); \
     return static_cast<void *>(map_ptr); }
     MMAP_VALSTORE_LOAD(float32)
+    MMAP_VALSTORE_LOAD(str)
 
     // Create view from external values pointer
     void mmap_valstore_from_vals_float32 (
@@ -605,6 +612,16 @@ extern "C" {
         const mmap_valstore_float32::value_type* vals
     ) {
         static_cast<mmap_valstore_float32 *>(map_ptr)->from_vals(n_row, n_col, vals);
+    }
+    // Allocate and Init
+    void mmap_valstore_from_vals_str (
+        void* map_ptr,
+        const row_type n_row,
+        const col_type n_col,
+        const char* const* vals,
+        const mmap_valstore_str::str_len_type* vals_lens
+    ) {
+        static_cast<mmap_valstore_str *>(map_ptr)->from_vals(n_row, n_col, vals, vals_lens);
     }
 
     // Get sub-matrix
@@ -619,5 +636,19 @@ extern "C" {
     ) {
         static_cast<mmap_valstore_float32 *>(map_ptr)->get_submatrix(
             n_sub_row, n_sub_col, sub_rows, sub_cols, ret, threads);
+    }
+    void mmap_valstore_get_submatrix_str (
+        void* map_ptr,
+        const uint32_t n_sub_row,
+        const uint32_t n_sub_col,
+        const row_type* sub_rows,
+        const col_type* sub_cols,
+        const mmap_valstore_str::str_len_type trunc_val_len,
+        char* ret,
+        mmap_valstore_str::str_len_type* ret_lens,
+        const int threads
+    ) {
+        static_cast<mmap_valstore_str *>(map_ptr)->get_submatrix(
+            n_sub_row, n_sub_col, sub_rows, sub_cols, trunc_val_len, ret, ret_lens, threads);
     }
 }

--- a/pecos/core/utils/mmap_valstore.hpp
+++ b/pecos/core/utils/mmap_valstore.hpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+ * with the License. A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+#ifndef __MMAP_VALSTORE_H__
+#define __MMAP_VALSTORE_H__
+
+#include <omp.h>
+#include "mmap_util.hpp"
+
+
+namespace pecos {
+namespace mmap_valstore {
+
+typedef uint64_t row_type;
+typedef uint32_t col_type;
+
+
+class Float32Store {
+    typedef float float32_t;
+
+    public:
+        typedef float32_t value_type;
+
+        Float32Store():
+            n_row_(0),
+            n_col_(0),
+            vals_(nullptr)
+        {}
+
+        row_type n_row() {
+            return n_row_;
+        }
+
+        col_type n_col() {
+            return n_col_;
+        }
+
+        // View from external values pointer, does not hold memory
+        void from_vals(const row_type n_row, const col_type n_col, const value_type* vals) {
+            n_row_ = n_row;
+            n_col_ = n_col;
+            vals_ = vals;
+        }
+
+        void get_submatrix(const uint32_t n_sub_row, const uint32_t n_sub_col, const row_type* sub_rows, const col_type* sub_cols, value_type* ret, const int threads=1) {
+            #pragma omp parallel for schedule(static, 1) num_threads(threads)
+            for (uint32_t i=0; i<n_sub_row; ++i) {
+                for (uint32_t j=0; j<n_sub_col; ++j) {
+                    ret[i * n_sub_col + j] = vals_[sub_rows[i] * n_col_ + sub_cols[j]];
+                }
+            }
+        }
+
+        void save(const std::string& folderpath) {
+            auto mmap_s = pecos::mmap_util::MmapStore();
+            mmap_s.open(mmap_file_name(folderpath), "w");
+
+            mmap_s.fput_one<row_type>(n_row_);
+            mmap_s.fput_one<col_type>(n_col_);
+            mmap_s.fput_multiple<value_type>(vals_, n_row_ * n_col_);
+
+            mmap_s.close();
+        }
+
+        void load(const std::string& folderpath, const bool lazy_load) {
+            mmap_store_.open(mmap_file_name(folderpath), lazy_load?"r_lazy":"r");
+
+            n_row_ = mmap_store_.fget_one<row_type>();
+            n_col_ = mmap_store_.fget_one<col_type>();
+            vals_ = mmap_store_.fget_multiple<value_type>(n_row_ * n_col_);
+        }
+
+
+    private:
+        row_type n_row_;
+        col_type n_col_;
+        const value_type* vals_;
+
+        pecos::mmap_util::MmapStore mmap_store_;
+
+        inline std::string mmap_file_name(const std::string& folderpath) const {
+            return folderpath + "/numerical_float32_2d.mmap_store";
+        }
+};
+
+
+
+} // end namespace mmap_valstore
+} // end namespace pecos
+
+#endif  // end of __MMAP_VALSTORE_H__

--- a/pecos/core/utils/mmap_valstore.hpp
+++ b/pecos/core/utils/mmap_valstore.hpp
@@ -16,6 +16,7 @@
 
 #include <omp.h>
 #include "mmap_util.hpp"
+// #include <iostream>
 
 
 namespace pecos {
@@ -94,6 +95,102 @@ class Float32Store {
 };
 
 
+class StringStore {
+    public:
+        typedef uint32_t str_len_type;
+
+        StringStore():
+            n_row_(0),
+            n_col_(0)
+        {}
+
+        row_type n_row() {
+            return n_row_;
+        }
+
+        col_type n_col() {
+            return n_col_;
+        }
+
+        // In memory. Allocate and assign values
+        void from_vals(const row_type n_row, const col_type n_col, const char* const* vals, const str_len_type* vals_lens) {
+            n_row_ = n_row;
+            n_col_ = n_col;
+
+            // Allocation
+            row_type n_total = n_row * n_col;
+            row_type n_total_char = 0;
+            for (row_type i=0; i<n_total; ++i) {
+                n_total_char += vals_lens[i];
+            }
+            vals_.resize(n_total_char);
+            vals_lens_.resize(n_total);
+            vals_starts_.resize(n_total);
+
+            // Assign the MmapVector
+            row_type cur_start = 0;
+            for (row_type i=0; i<n_total; ++i) {
+                vals_lens_[i] = vals_lens[i];
+                vals_starts_[i] = cur_start;
+                std::memcpy(vals_.data() + cur_start, vals[i], vals_lens[i]);
+                cur_start += vals_lens[i];
+            }
+        }
+
+        void get_submatrix(const uint32_t n_sub_row, const uint32_t n_sub_col, const row_type* sub_rows, const col_type* sub_cols,
+            const str_len_type trunc_val_len, char* ret, str_len_type* ret_lens, const int threads=1) {
+            #pragma omp parallel for schedule(static, 1) num_threads(threads)
+            for (uint32_t i=0; i<n_sub_row; ++i) {
+                for (uint32_t j=0; j<n_sub_col; ++j) {
+                    uint32_t sub_idx = i * n_sub_col + j;
+                    row_type idx = sub_rows[i] * n_col_ + sub_cols[j];
+                    uint32_t ret_start_idx = sub_idx * trunc_val_len;
+                    str_len_type cur_ret_len = std::min(trunc_val_len, vals_lens_[idx]);
+                    ret_lens[sub_idx] = cur_ret_len;
+                    std::memcpy(ret + ret_start_idx, vals_.data() + vals_starts_[idx], cur_ret_len);
+                }
+            }
+        }
+
+        void save(const std::string& folderpath) {
+            auto mmap_s = pecos::mmap_util::MmapStore();
+            mmap_s.open(mmap_file_name(folderpath), "w");
+
+            mmap_s.fput_one<row_type>(n_row_);
+            mmap_s.fput_one<col_type>(n_col_);
+
+            vals_.save_to_mmap_store(mmap_s);
+            vals_lens_.save_to_mmap_store(mmap_s);
+            vals_starts_.save_to_mmap_store(mmap_s);
+
+            mmap_s.close();
+        }
+
+        void load(const std::string& folderpath, const bool lazy_load) {
+            mmap_store_.open(mmap_file_name(folderpath), lazy_load?"r_lazy":"r");
+
+            n_row_ = mmap_store_.fget_one<row_type>();
+            n_col_ = mmap_store_.fget_one<col_type>();
+
+            vals_.load_from_mmap_store(mmap_store_);
+            vals_lens_.load_from_mmap_store(mmap_store_);
+            vals_starts_.load_from_mmap_store(mmap_store_);
+        }
+
+
+    private:
+        row_type n_row_;
+        col_type n_col_;
+        mmap_util::MmapableVector<char> vals_;  // Concatenated big string
+        mmap_util::MmapableVector<str_len_type> vals_lens_;  // Length for each string
+        mmap_util::MmapableVector<row_type> vals_starts_;  // Start for each string in the concatenated big string
+
+        pecos::mmap_util::MmapStore mmap_store_;
+
+        inline std::string mmap_file_name(const std::string& folderpath) const {
+            return folderpath + "/string_2d.mmap_store";
+        }
+};
 
 } // end namespace mmap_valstore
 } // end namespace pecos

--- a/pecos/utils/mmap_valstore_util.py
+++ b/pecos/utils/mmap_valstore_util.py
@@ -1,0 +1,309 @@
+#  Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+#  with the License. A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0/
+#
+#  or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+#  OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+#  and limitations under the License.
+import logging
+from abc import abstractmethod
+from pecos.core import clib
+from typing import Optional
+from ctypes import c_uint32, c_uint64, c_float, POINTER
+import numpy as np
+import os
+
+LOGGER = logging.getLogger(__name__)
+
+
+class MmapValStore(object):
+    """
+    Python wrapper of memory-mapped 2D matrix value store.
+    """
+
+    def __init__(self, store_type: str):
+        if store_type not in clib.mmap_valstore_fn_dict:
+            raise NotImplementedError(f"store_type={store_type} is not implemented.")
+
+        self.store_type = store_type
+        self.store = None
+        self.mode: Optional[str] = None
+        self.store_dir: Optional[str] = None
+
+    def open(self, mode: str, store_dir: str):
+        """
+        Open value store at given directory for read-only or write-only.
+        For write-only, the value store exists in RAM until dumps to given directory when closing.
+
+        args:
+            mode: Open mode, in "w", "r", "r_lazy"(not pre-load).
+            store_dir: Directory to load from/save to.
+        """
+        if mode == "w":
+            store = _MmapValStoreWrite.init(self.store_type, store_dir)
+            LOGGER.info(f"Opened value store for writing. Will save to {store_dir} upon closing.")
+        elif mode == "r" or mode == "r_lazy":
+            lazy_load = True if mode == "r_lazy" else False
+            store = _MmapValStoreReadOnly.init(self.store_type, store_dir, lazy_load)
+            LOGGER.info(
+                f"Opened value store for read-only. Will {'NOT' if lazy_load else ''} pre-load."
+            )
+        else:
+            raise NotImplementedError(f"{mode} not implemented.")
+
+        self.store = store
+        self.mode = mode
+        self.store_dir = store_dir
+
+    def close(self):
+        """
+        Close and destruct value store.
+        For write-only, dumps to given directory.
+        """
+        if self.mode == "w":
+            self.store.save()
+            LOGGER.info(f"Saved value store to {self.store_dir} upon closing.")
+        self.store.destruct()
+        LOGGER.info("Destructed value store upon closing.")
+        self.store = None
+        self.mode = None
+        self.store_dir = None
+
+    def __del__(self):
+        """
+        Destructor to call close() if not called previously
+        """
+        if self.store is not None:
+            self.close()
+
+
+class MmapValStoreSubMatGetter(object):
+    """
+    Sub-matrix getter for MmapValStore opened for readonly.
+
+    Args:
+        max_row_size: Maximum row size
+        max_col_size: Maximum column size
+        max_val_len (Optional): Applicable for string value only. Truncated max string length.
+        threads (Optional): Number of threads to use.
+    """
+
+    def __init__(
+        self,
+        store_r,
+        max_row_size: int,
+        max_col_size: int,
+        max_val_len: int = 256,
+        threads: int = 1,
+    ):
+        if not isinstance(store_r, _MmapValStoreReadOnly):
+            raise ValueError(f"Should get from readonly MmapValStore, got {type(store_r)}")
+        if max_row_size <= 0:
+            raise ValueError(f"Max row size should >0, got {max_row_size}")
+        if max_col_size <= 0:
+            raise ValueError(f"Max col size should >0, got {max_col_size}")
+        if threads <= 0 and threads != -1:
+            raise ValueError(f"Number of threads should >0 or =-1, got {threads}")
+
+        self.store_r: Optional[_MmapValStoreReadOnly] = store_r
+
+        # `os.cpu_count()` is not equivalent to the number of CPUs the current process can use.
+        # The number of usable CPUs can be obtained with len(os.sched_getaffinity(0))
+        n_usable_cpu = len(os.sched_getaffinity(0))
+        self.threads_c_uint32 = c_uint32(
+            min(n_usable_cpu, n_usable_cpu if threads == -1 else threads)
+        )
+
+        # Pre-allocated space for sub-matrix row & col indices
+        self.sub_rows = np.zeros(max_row_size, dtype=np.uint64)
+        self.sub_cols = np.zeros(max_col_size, dtype=np.uint32)
+        self.sub_rows_ptr = self.sub_rows.ctypes.data_as(POINTER(c_uint64))
+        self.sub_cols_ptr = self.sub_cols.ctypes.data_as(POINTER(c_uint32))
+
+        # Pre-allocated space for return values sub-matrix
+        self.val_prealloc = store_r.get_val_alloc(max_row_size, max_col_size, max_val_len)
+
+    def get_submat(self, rows, cols):
+        """
+        Get sub-matrix of the value store with given indices of rows and columns.
+
+        NOTE:
+            1) `rows` & `cols` are list-like objects,
+                e.g. List, np array, memoryview returned from MmapHashmap batch_get
+            2) The return is a reused buffer, use or copy the data once you get it. It is not guaranteed to last.
+        """
+        n_rows = len(rows)
+        n_cols = len(cols)
+        self.sub_rows.flat[:n_rows] = rows
+        self.sub_cols.flat[:n_cols] = cols
+        self.store_r.get_submatrix(
+            n_rows,
+            n_cols,
+            self.sub_rows_ptr,
+            self.sub_cols_ptr,
+            self.val_prealloc.vals_ptr,
+            self.threads_c_uint32,
+        )
+        return self.val_prealloc.get_ret_memoryview(n_rows, n_cols)
+
+
+class _MmapValStoreBase(object):
+    """Base class for methods shared by all modes"""
+
+    def __init__(self, store_ptr, fn_dict):
+        self.store_ptr = store_ptr
+        self.fn_dict = fn_dict
+
+    def n_row(self):
+        return self.fn_dict["n_row"](self.store_ptr)
+
+    def n_col(self):
+        return self.fn_dict["n_col"](self.store_ptr)
+
+    def destruct(self):
+        self.fn_dict["destruct"](self.store_ptr)
+
+
+class _MmapValStoreReadOnly(_MmapValStoreBase):
+    """Base class for methods shared by all read modes"""
+
+    @abstractmethod
+    def get_submatrix(self, n_rows, n_cols, rows_ptr, cols_ptr, ret_val_ptr, threads_c_uint32):
+        pass
+
+    @classmethod
+    @abstractmethod
+    def get_val_alloc(cls, max_row_size: int, max_col_size: int, max_val_len: int = 256):
+        """
+        Get reusable return value pre-allocations.
+
+        Args:
+            max_row_size: Maximum row size
+            max_col_size: Maximum column size
+            max_val_len (Optional): Applicable for string value only. Maximum string length.
+        """
+        pass
+
+    @classmethod
+    def init(cls, store_type, store_dir, lazy_load):
+        fn_dict = clib.mmap_valstore_init(store_type)
+        store_ptr = fn_dict["load"](store_dir.encode("utf-8"), lazy_load)
+
+        if store_type == "num_f32":
+            return _MmapValStoreNumF32ReadOnly(store_ptr, fn_dict)
+        elif store_type == "string":
+            return _MmapValStoreStrReadOnly(store_ptr, fn_dict)
+        else:
+            raise NotImplementedError(f"{store_type}")
+
+
+class _MmapValStoreNumF32ReadOnly(_MmapValStoreReadOnly):
+    """
+    Numerical float32 value store read only implementation.
+    """
+
+    def get_submatrix(self, n_rows, n_cols, rows_ptr, cols_ptr, ret_val_ptr, threads_c_uint32):
+        self.fn_dict["get_submatrix"](
+            self.store_ptr, n_rows, n_cols, rows_ptr, cols_ptr, ret_val_ptr, threads_c_uint32
+        )
+
+    @classmethod
+    def get_val_alloc(cls, max_row_size: int, max_col_size: int, max_val_len: int = 0):
+        return _NumF32SubMatGetterValPreAlloc(max_row_size, max_col_size)
+
+
+class _NumF32SubMatGetterValPreAlloc(object):
+    """
+    Sub-matrix return value pre-allocate for float32 Numerical MmapValStore.
+    """
+
+    def __init__(self, max_row_size: int, max_col_size: int):
+        self.vals = np.zeros(max_row_size * max_col_size, dtype=np.float32)
+        self.vals_ptr = self.vals.ctypes.data_as(POINTER(c_float))
+
+    def get_ret_memoryview(self, n_rows, n_cols):
+        """
+        Reshape return into desired shape (row-major), so elements could be retrieved by indices:
+            ret[i, j], 0<=i<n_rows, 0<=j<n_cols
+
+        Return can also be assigned to row-major Numpy array of same shape:
+            arr = np.zeros((n_rows, n_cols), dtype=np.float32)
+            arr.flat[:] = ret
+        This also works:
+            arr = np.array(ret)
+
+        Casting/Reshaping a memoryview does not copy data.
+        See: https://docs.python.org/3/library/stdtypes.html#memoryview.cast
+        """
+        # Casting to bytes first then cast to float32 with desired shape.
+        # 'f' = float32
+        # For types, see: https://docs.python.org/3/library/struct.html#format-characters
+        return memoryview(self.vals)[: n_rows * n_cols].cast("c").cast("f", shape=[n_rows, n_cols])
+
+
+class _MmapValStoreStrReadOnly(_MmapValStoreReadOnly):
+    """
+    String value store read only implementation.
+    """
+
+    pass
+
+
+class _MmapValStoreWrite(_MmapValStoreBase):
+    """Base class for methods shared by all write modes"""
+
+    def __init__(self, store_ptr, fn_dict, store_dir):
+        super().__init__(store_ptr, fn_dict)
+        self.store_dir = store_dir
+
+        # Stored references if necessary
+        self.vals = None
+
+    @abstractmethod
+    def from_vals(self, vals):
+        pass
+
+    def save(self):
+        import pathlib
+
+        pathlib.Path(self.store_dir).mkdir(parents=True, exist_ok=True)
+        self.fn_dict["save"](self.store_ptr, (self.store_dir.encode("utf-8")))
+
+        # Delete stored references after save
+        self.vals = None
+
+    @classmethod
+    def init(cls, store_type, store_dir):
+        fn_dict = clib.mmap_valstore_init(store_type)
+        store_ptr = fn_dict["new"]()
+
+        if store_type == "num_f32":
+            return _MmapValStoreNumF32Write(store_ptr, fn_dict, store_dir)
+        elif store_type == "string":
+            return _MmapValStoreStrWrite(store_ptr, fn_dict, store_dir)
+        else:
+            raise NotImplementedError(f"{store_type}")
+
+
+class _MmapValStoreNumF32Write(_MmapValStoreWrite):
+    def from_vals(self, vals):
+        """
+        Args:
+            vals: 2D row-major numpy float32 array to write.
+        """
+        if not vals.flags["C_CONTIGUOUS"]:
+            raise ValueError("Array is not row-major, cannot write.")
+        n_row, n_col = vals.shape
+        self.fn_dict["from_vals"](
+            self.store_ptr, n_row, n_col, vals.ctypes.data_as(POINTER(c_float))
+        )
+        # Keep a reference to vals so it won't get recycled until this class instance is deleted
+        self.vals = vals
+
+
+class _MmapValStoreStrWrite(_MmapValStoreWrite):
+    def from_vals(self, vals):
+        pass

--- a/test/pecos/utils/test_mmap_valstore_util.py
+++ b/test/pecos/utils/test_mmap_valstore_util.py
@@ -1,0 +1,45 @@
+#  Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance
+#  with the License. A copy of the License is located at
+#
+#  http://aws.amazon.com/apache2.0/
+#
+#  or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+#  OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+#  and limitations under the License.
+import pytest  # noqa: F401; pylint: disable=unused-variable
+
+
+def test_num_mmap_valstore(tmpdir):
+    from pecos.utils.mmap_valstore_util import MmapValStore, MmapValStoreSubMatGetter
+    import numpy as np
+
+    map_dir = tmpdir.join("num_valstore").realpath().strpath
+
+    #  [[ 0.,  1.,  2.],
+    #   [ 3.,  4.,  5.],
+    #   [ 6.,  7.,  8.],
+    #   [ 9., 10., 11.],
+    #   [12., 13., 14.]]
+    arr = np.arange(15, dtype=np.float32).reshape(5, 3)
+
+    # Write-only Mode
+    w_store = MmapValStore("num_f32")
+    w_store.open("w", map_dir)
+    # from array
+    w_store.store.from_vals(arr)
+    # Size
+    assert w_store.store.n_row(), w_store.store.n_col() == arr.shape
+    w_store.close()
+
+    # Read-only Mode
+    r_store = MmapValStore("num_f32")
+    r_store.open("r", map_dir)
+    # Get sub-matrix
+    vs_getter = MmapValStoreSubMatGetter(r_store.store, max_row_size=10, max_col_size=10)
+    assert np.array(vs_getter.get_submat([0], [0])).tolist() == [[0.0]]
+    assert np.array(vs_getter.get_submat([0, 1], [0, 1])).tolist() == [[0.0, 1.0], [3.0, 4.0]]
+    assert np.array(vs_getter.get_submat([2, 3, 4], [1])).tolist() == [[7.0], [10.0], [13.0]]
+    assert np.array(vs_getter.get_submat([3, 1], [0, 2])).tolist() == [[9.0, 11.0], [3.0, 5.0]]
+    assert np.array(vs_getter.get_submat([4], [1, 0, 2])).tolist() == [[13.0, 12.0, 14.0]]


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Added Numerical (float32) C with Python binding mmap value store (2D matrix). 

Accelerates sub-matrix retrieval given rows and cols indices, comparing to for-loop `np.array.item(i, j)`.
For value store of 66M x 100, time cost of retrieving (Python binding) random sub-matrix 500x50, comparing to numpy for-loop is 0.09ms (4 threads) vs. 5ms 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.