### PR TITLE
Add C implementation to fit Platt scaling

### DIFF
--- a/pecos/core/libpecos.cpp
+++ b/pecos/core/libpecos.cpp
@@ -651,4 +651,18 @@ extern "C" {
         static_cast<mmap_valstore_bytes *>(map_ptr)->batch_get(
             n_sub_row, n_sub_col, sub_rows, sub_cols, trunc_val_len, ret, ret_lens, threads);
     }
+
+    // ==== C Interface of Score Calibrator ====
+
+    #define C_FIT_PLATT_TRANSFORM(SUFFIX, VAL_TYPE) \
+    void c_fit_platt_transform ## SUFFIX( \
+        size_t num_samples, \
+	const VAL_TYPE* logits, \
+	const VAL_TYPE* tgt_probs, \
+	double* AB \
+    ) { \
+        pecos::fit_platt_transform(num_samples, logits, tgt_probs, AB[0], AB[1]); \
+    }
+    C_FIT_PLATT_TRANSFORM(_f32, float32_t)
+    C_FIT_PLATT_TRANSFORM(_f64, float64_t)
 }

--- a/test/pecos/core/test_clib.py
+++ b/test/pecos/core/test_clib.py
@@ -67,3 +67,23 @@ def test_sparse_inner_products():
     assert true_vals == approx(
         pred_vals, abs=1e-9
     ), f"true_vals != pred_vals, where X/Y are drm/dcm"
+
+
+def test_platt_scale():
+    import numpy as np
+    from pecos.core import clib
+
+    A = 0.25
+    B = 3.14
+
+    orig = np.arange(-15, 15, 1, dtype=np.float32)
+    tgt = np.array([1.0 / (1 + np.exp(A * t + B)) for t in orig], dtype=np.float32)
+    At, Bt = clib.fit_platt_transform(orig, tgt)
+    assert B == approx(Bt, abs=1e-6), f"Platt_scale B error: {B} != {Bt}"
+    assert A == approx(At, abs=1e-6), f"Platt_scale A error: {A} != {At}"
+
+    orig = np.arange(-15, 15, 1, dtype=np.float64)
+    tgt = np.array([1.0 / (1 + np.exp(A * t + B)) for t in orig], dtype=np.float64)
+    At, Bt = clib.fit_platt_transform(orig, tgt)
+    assert B == approx(Bt, abs=1e-6), f"Platt_scale B error: {B} != {Bt}"
+    assert A == approx(At, abs=1e-6), f"Platt_scale A error: {A} != {At}"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Add C implementation to fit Platt scaling with Newton method.
* Expose Python API `clib.fit_platt_transform`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.