### PR TITLE
Fix train/predict bugs in PairwiseANN

### DIFF
--- a/pecos/core/libpecos.cpp
+++ b/pecos/core/libpecos.cpp
@@ -543,7 +543,7 @@ extern "C" {
     void c_pairwise_ann_predict ## SUFFIX( \
         void* searchers_ptr, \
         uint32_t batch_size, \
-        uint32_t topk, \
+        uint32_t only_topk, \
         const PY_MAT* pQ, \
         uint32_t* label_keys, \
         uint32_t* ret_Imat, \
@@ -559,9 +559,9 @@ extern "C" {
             int tid = omp_get_thread_num(); \
             auto input_key = (is_same_input ? 0 : bidx); \
             auto label_key = label_keys[bidx]; \
-            auto& ret_pairs = searchers[tid].predict_single(Q_tst.get_row(input_key), label_key, topk); \
+            auto& ret_pairs = searchers[tid].predict_single(Q_tst.get_row(input_key), label_key, only_topk); \
             for (uint32_t k=0; k < ret_pairs.size(); k++) { \
-                uint64_t offset = static_cast<uint64_t>(bidx) * topk; \
+                uint64_t offset = static_cast<uint64_t>(bidx) * only_topk; \
                 ret_Imat[offset + k] = ret_pairs[k].input_key_idx; \
                 ret_Dmat[offset + k] = ret_pairs[k].input_key_dist; \
                 ret_Vmat[offset + k] = ret_pairs[k].input_label_val; \

--- a/pecos/core/utils/matrix.hpp
+++ b/pecos/core/utils/matrix.hpp
@@ -106,7 +106,7 @@ namespace pecos {
                         if(touched_indices[i] < len) {
                             touched_indices[write_pos] = touched_indices[i];
                             write_pos += 1;
-                        } 
+                        }
                     }
                     nr_touch = write_pos;
                 }
@@ -540,6 +540,34 @@ namespace pecos {
         mem_index_type get_nnz() const {
             return static_cast<mem_index_type>(rows) * static_cast<mem_index_type>(cols);
         }
+
+        // Frees the underlying memory of the matrix (i.e., col_ptr, row_idx, and val arrays)
+        // Every function in the inference code that returns a matrix has allocated memory, and
+        // therefore one should call this function to free that memory.
+        void free_underlying_memory() {
+            if (val) {
+                delete[] val;
+                val = nullptr;
+            }
+        }
+
+        // Creates a deep copy of this matrix
+        // This allocates memory, so one should call free_underlying_memory on the copy when
+        // one is finished using it.
+        drm_t deep_copy() const {
+            mem_index_type nnz = get_nnz();
+            drm_t res;
+            res.allocate(rows, cols, nnz);
+            std::memcpy(res.val, val, sizeof(value_type) * nnz);
+            return res;
+        }
+
+        void allocate(index_type rows, index_type cols, mem_index_type nnz) {
+            this->rows = rows;
+            this->cols = cols;
+            val = new value_type[nnz];
+        }
+
     };
 
     struct dcm_t { // Dense Column Majored Matrix


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix train/predict bugs in PairwiseANN:
(1) For training, deep copy the `X_trn` and `Y_csc` matrix, to prevent pX/pY being modified and deleted at Python level. Otherwise, the PairwiseANN index may save the wrong content, or facing sagmentation fault.
(2) For inference, searchers take in the `pred_params`, which pre-allocate the memory of return numpy array. We do not accept different `topk` at PairwiseANN.predict(), as it cause complexity to slice the returned matrix back.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.