### PR TITLE
bug fix: generate directory if path not exist in compile_mmap_model

### DIFF
--- a/pecos/xmc/xlinear/model.py
+++ b/pecos/xmc/xlinear/model.py
@@ -95,8 +95,8 @@ class XLinearModel(pecos.BaseClass):
         Args:
             model_folder (str): dir to save the model
         """
-        if not path.exists(model_folder):
-            os.makedirs(model_folder)
+
+        os.makedirs(model_folder, exist_ok=True)
         param = self.append_meta({})
         with open(f"{model_folder}/param.json", "w", encoding="utf-8") as fout:
             fout.write(json.dumps(param, indent=True))
@@ -144,6 +144,7 @@ class XLinearModel(pecos.BaseClass):
         """
         import shutil
 
+        os.makedirs(mmap_folder, exist_ok=True)
         shutil.copyfile(path.join(npz_folder, "param.json"), path.join(mmap_folder, "param.json"))
         HierarchicalMLModel.compile_mmap_model(
             path.join(npz_folder, "ranker"), path.join(mmap_folder, "ranker")

--- a/test/pecos/xmc/xlinear/test_xlinear.py
+++ b/test/pecos/xmc/xlinear/test_xlinear.py
@@ -1138,7 +1138,6 @@ def test_predict_consistency_between_topk_and_selected(tmpdir):
 
 
 def test_mmap(tmpdir):
-    from pathlib import Path
     from pecos.utils import smat_util
     from pecos.xmc.xlinear import XLinearModel
     from pecos.xmc import PostProcessor
@@ -1153,7 +1152,6 @@ def test_mmap(tmpdir):
 
     npz_model_folder = str(tmpdir.join("save_model_npz"))
     mmap_model_folder = str(tmpdir.join("save_model_mmap"))
-    Path(mmap_model_folder).mkdir(parents=True, exist_ok=True)
     py_model.save(npz_model_folder)
     XLinearModel.compile_mmap_model(npz_model_folder, mmap_model_folder)
     mmap_model = XLinearModel.load(mmap_model_folder, is_predict_only=True)


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Generate directory if path not exist when saving a XLinearModel. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.