### PR TITLE
Update numpy, scipy, OpenBLAS, and setuptools version

### DIFF
--- a/.github/build_pypi_wheel.sh
+++ b/.github/build_pypi_wheel.sh
@@ -20,19 +20,14 @@ echo "pip: $($PIP --version)"
 
 # Install dependencies
 echo "Install dependencies..."
-# Temporarily pin setuptools version due to a recent bug, which will be fix in their later updates
-# See: https://github.com/pypa/setuptools/issues/3532
-# https://github.com/numpy/numpy/issues/22135
-$PIP install 'setuptools<=60.0.*' wheel twine auditwheel
+$PIP install setuptools wheel twine auditwheel
 
 # Install OpenBLAS
-# Using Numpy pre-build OpenBLAS lib v0.3.19 hosted on Anaconda
+# Using pre-build OpenBLAS lib v0.3.27 hosted on Anaconda
 # Refer to: https://github.com/MacPython/openblas-libs
 # OpenBLAS64 is for ILP64, which is not our case
-# Details see Numpy OpenBLAS downloader:
-# https://github.com/numpy/numpy/blob/main/tools/openblas_support.py#L19
 if [ "$PLAT" = "manylinux2014_x86_64" ] || [ "$PLAT" = "manylinux2014_aarch64" ]; then
-   OPENBLAS_VER="v0.3.19-22-g5188aede"
+   OPENBLAS_VER="v0.3.27"
    OPENBLAS_LIB="openblas-${OPENBLAS_VER}-${PLAT}.tar.gz"
    OPENBLAS_LIB_URL="https://anaconda.org/multibuild-wheels-staging/openblas-libs/$OPENBLAS_VER/download/$OPENBLAS_LIB"
    yum install wget -y

--- a/.github/workflows/pytest_aarch64.yml
+++ b/.github/workflows/pytest_aarch64.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v3
       with:
         platforms: all
 

--- a/setup.py
+++ b/setup.py
@@ -107,13 +107,13 @@ with open("README.md", "r", encoding="utf-8") as f:
 # Requirements
 numpy_requires = [
     'numpy<1.20.0; python_version<"3.7"', # setup_requires needs correct version for <3.7
-    'numpy>=1.19.5; python_version>="3.7"'
+    'numpy>=1.19.5,<2.0.0; python_version>="3.7"'
 ]
 setup_requires = numpy_requires + [
     'pytest-runner'
 ]
 install_requires = numpy_requires + [
-    'scipy>=1.4.1',
+    'scipy>=1.4.1,<1.14.0',
     'scikit-learn>=0.24.1',
     'torch==1.13; python_version<"3.8"',
     'torch>=2.0; python_version>="3.8"',


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
- Update scipy/numpy version
- Update OpenBLAS version to v0.3.27. Latest version found here: https://anaconda.org/multibuild-wheels-staging/openblas-libs/files
- Remove pin on setuptools version

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.