### PR TITLE
Remove Support of Py3.7 and Support Py3.11

### DIFF
--- a/.github/workflows/build_pypi.yml
+++ b/.github/workflows/build_pypi.yml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 4
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         build_platform: ["manylinux2014_x86_64", "manylinux2014_aarch64"]
 
     runs-on: ubuntu-20.04

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -9,7 +9,7 @@ jobs:
       max-parallel: 4
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         platform: [ubuntu-20.04, ubuntu-22.04]
 
     runs-on: ${{ matrix.platform }}
@@ -38,7 +38,7 @@ jobs:
       max-parallel: 4
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     runs-on: ubuntu-latest
     container: amazonlinux:2

--- a/.github/workflows/style_type_check.yml
+++ b/.github/workflows/style_type_check.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: "3.7"
+        python-version: "3.8"
     - name: Install dependencies
       id: install-dep
       run: |

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Given an input, PECOS identifies a small set (10-100) of relevant outputs from a
 
 ## Requirements and Installation
 
-* Python (3.7, 3.8, 3.9, 3.10)
+* Python (3.8, 3.9, 3.10, 3.11)
 * Pip (>=19.3)
 
 See other dependencies in [`setup.py`](https://github.com/amzn/pecos/blob/mainline/setup.py#L135)

--- a/setup.py
+++ b/setup.py
@@ -106,8 +106,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 # Requirements
 numpy_requires = [
-    'numpy<1.20.0; python_version<"3.7"', # setup_requires needs correct version for <3.7
-    'numpy>=1.19.5,<2.0.0; python_version>="3.7"'
+    'numpy>=1.19.5,<2.0.0; python_version>="3.8"'
 ]
 setup_requires = numpy_requires + [
     'pytest-runner'
@@ -115,11 +114,11 @@ setup_requires = numpy_requires + [
 install_requires = numpy_requires + [
     'scipy>=1.4.1,<1.14.0',
     'scikit-learn>=0.24.1',
-    'torch==1.13; python_version<"3.8"',
     'torch>=2.0; python_version>="3.8"',
     'sentencepiece>=0.1.86,!=0.1.92', # 0.1.92 results in error for transformers
-    'transformers>=4.1.1; python_version<"3.9"',
-    'transformers>=4.4.2; python_version>="3.9"'
+    'transformers>=4.31.0; python_version>="3.8"',  # the minimal version supporting py3.8
+    'peft>=0.11.0; python_version>="3.8"',
+    'datasets>=2.19.1; python_version>="3.8"',
 ]
 
 # Fetch Numpy before building Numpy-dependent extension, if Numpy required version was not installed


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Remove support for Python Version 3.7, as its marked End-of-Life for more than 1 year [[ref](https://devguide.python.org/versions/)];
- Add support for Python Version 3.11 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.