### PR TITLE
pin setuptools version to 73.0.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,10 @@ mypy:
 
 
 # Install and unit test
+# TODO: remove pin on pip and setuptools after removing numpy.distutils
 libpecos:
-	python3 -m pip install --upgrade pip
+	python3 -m pip install pip==23.0.1
+	python3 -m pip install "setuptools<=73.0.1"
 	${WARN_AS_ERROR_CMD} python3 -m pip install ${VFLAG} --editable .
 
 .PHONY: test

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,10 @@
 [aliases]
 test=pytest
 
+# TODO: remove pin on setuptools version after removing numpy.distutils
+[build-system]
+requires = ["setuptools<=73.0.1"]
+
 # Configuration for pytest; enable coverage for pecos, emit
 # XML, HTML, and terminal reports.
 [tool:pytest]

--- a/setup.py
+++ b/setup.py
@@ -106,6 +106,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 # Requirements
 numpy_requires = [
+    'setuptools<=73.0.1', # TODO: remove pin on setuptools version after removing numpy.distutils
     'numpy>=1.19.5,<2.0.0; python_version>="3.8"'
 ]
 setup_requires = numpy_requires + [


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Pin the version of `setuptools` to be 73.0.1. The latest version of `setuptools` is 74.0.0 and Github workflow fails with message:
```
ModuleNotFoundError: No module named 'distutils.msvccompiler'
```
According to the [release notes](https://setuptools.pypa.io/en/stable/history.html#v74-0-0) of `setuptools`, `distutils` has been deprecated. Reading from the [Numpy docs](https://numpy.org/doc/stable/reference/distutils.html), `distutils` also is marked as deprecated. The solution provided is to temporarily pin down the version of `setuptools` to the last known working version of our build which is version 73.0.1.

Testing the pin down version of setuptools, we get the following error: `ERROR: Some build dependencies for file:///home/ec2-user/pecos conflict with the backend dependencies: setuptools==74.0.0 is incompatible with setuptools<=73.0.1.` We pin down `pip` to the highest version possible without getting this error which is `pip==23.0.1`.

Pinning down `setuptools` and `pip` is temporary and the following weeks, we should move away from `distutils` and revert these changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.