### PR TITLE
Refactor RankingModel class for Text+Numr use case

### DIFF
--- a/.github/build_pypi_wheel.sh
+++ b/.github/build_pypi_wheel.sh
@@ -19,8 +19,9 @@ echo "pip: $($PIP --version)"
 
 
 # Install dependencies
+# TODO: remove pin on setuptools after removing numpy.distutils
 echo "Install dependencies..."
-$PIP install setuptools wheel twine auditwheel
+$PIP install 'setuptools<=73.0.1' wheel twine auditwheel
 
 # Install OpenBLAS
 # Using pre-build OpenBLAS lib v0.3.27 hosted on Anaconda

--- a/examples/msmarco-rankllama/README.md
+++ b/examples/msmarco-rankllama/README.md
@@ -1,0 +1,33 @@
+# PECOS XMR Reranker on MS-Marco Dataset
+
+This is an example of PECOS-based RankingModel that reproduced the [RankLlaMA paper](https://arxiv.org/abs/2310.08319).
+
+## How to run
+
+### Training
+```bash
+torchrun --nnodes 1 --nproc-per-node 8 \
+    -m pecos.xmr.reranker.train \
+    --config_json_path ./msmarco_qwen2-7B.train.json
+```
+
+### Predictions
+```bash
+python -m pecos.xmr.reranker.predict \
+    --config_json_path ./msmarco_qwen2-7B.pred.json
+```
+
+## Evaluation
+We first convert the predictions from parquet to TREC format:
+```python
+python -u parquet_to_trec_eval.py -i inference_outputs/ms_marco/qwen2-7B -o inference_outputs/ms_marco/qwen2-7B.pred.trec
+```
+
+We then follow [Pyserini]() evaluation protocol to eval the NDCG@10,
+and you should see the results like:
+```python
+python -m pyserini.eval.trec_eval -c -m ndcg_cut.10 dl19-passage inference_outputs/ms_marco/qwen2-7B.pred.trec 
+
+Results:
+ndcg_cut_10             all     0.7619
+```

--- a/examples/msmarco-rankllama/msmarco_qwen2-7B.pred.json
+++ b/examples/msmarco-rankllama/msmarco_qwen2-7B.pred.json
@@ -1,0 +1,21 @@
+{
+    "target_data_folder": "./datasets/ms_marco/eval_aux/target",
+    "input_data_folder":  "./datasets/ms_marco/eval_aux/input",
+    "label_data_folder":  "./datasets/ms_marco/eval_aux/label",
+    "model_path": "./models/ms_marco/qwen2-7B/",
+    "output_dir": "./inference_outputs/ms_marco/qwen2-7B/",
+    "per_device_eval_batch_size": 1024,
+    "dataloader_num_workers": 1,
+    "dataloader_prefetch_factor": 10,
+    "rerank_max_len": 196,
+    "query_prefix": "query: ",
+    "passage_prefix": "document: ",
+    "inp_id_col": "inp_id",
+    "lbl_id_col": "lbl_id",
+    "inp_id_orig_col": "inp_id_orig",
+    "lbl_id_orig_col": "lbl_id_orig",
+    "keyword_col_name": "keywords",
+    "content_col_names": ["title", "contents"],
+    "append_eos_token": false,
+    "pad_to_multiple_of": 8
+}

--- a/examples/msmarco-rankllama/msmarco_qwen2-7B.train.json
+++ b/examples/msmarco-rankllama/msmarco_qwen2-7B.train.json
@@ -1,0 +1,140 @@
+{
+    "train_params": {
+        "__meta__": {
+            "class_fullname": "pecos.xmr.reranker.model###RankingModel.TrainParams"
+        },
+        "target_data_folder": "./datasets/ms_marco/train/target",
+        "input_data_folder":  "./datasets/ms_marco/train/input",
+        "label_data_folder":  "./datasets/ms_marco/train/label",
+        "hf_trainer_args": {
+            "__meta__": {
+                "class_fullname": "pecos.xmr.reranker.trainer###RankingTrainer.TrainingArgs"
+            },
+            "output_dir": "./models/ms_marco/qwen2-7B",
+	    "ddp_find_unused_parameters": false,
+            "loss_fn": "listwise",
+	    "loss_alpha": 1.0,
+	    "group_size": 16,
+            "per_device_train_batch_size": 6,
+            "gradient_accumulation_steps": 8,
+	    "disable_tqdm": false,
+            "logging_strategy": "steps",
+            "logging_first_step": false,
+            "learning_rate": 1e-4,
+            "max_steps": 1500,
+            "save_steps": 50,
+            "logging_steps": 10,
+            "save_strategy": "steps",
+            "save_total_limit": 5,
+            "seed": 42,
+            "data_seed": 42,
+            "bf16": true,
+            "dataloader_num_workers": 2,
+            "dataloader_prefetch_factor": 10,
+            "gradient_checkpointing": true,
+            "deepseed": {
+                "zero_optimization": {
+                    "stage": 3,
+                    "offload_optimizer": {
+                        "device": "none",
+                        "pin_memory": true
+                    },
+                    "offload_param": {
+                        "device": "none",
+                        "pin_memory": true
+                    },
+                    "overlap_comm": true,
+                    "contiguous_gradients": true,
+                    "sub_group_size": 1e9,
+                    "reduce_bucket_size": 1e6,
+                    "stage3_prefetch_bucket_size": "auto",
+                    "stage3_param_persistence_threshold": "auto",
+                    "stage3_max_live_parameters": 1e9,
+                    "stage3_max_reuse_distance": 1e9,
+                    "stage3_gather_16bit_weights_on_model_save": true
+                },
+                "fp16": {
+                    "enabled": "auto",
+                    "loss_scale": 0,
+                    "initial_scale_power": 10,
+                    "loss_scale_window": 1000,
+                    "hysteresis": 2,
+                    "min_loss_scale": 1
+                },
+                "bf16": {
+                    "enabled": "auto",
+                    "loss_scale": 0,
+                    "initial_scale_power": 10,
+                    "loss_scale_window": 1000,
+                    "hysteresis": 2,
+                    "min_loss_scale": 1
+                },
+                "optimizer": {
+                    "type": "AdamW",
+                    "params": {
+                        "lr": "auto",
+                        "betas": "auto",
+                        "eps": "auto",
+                        "weight_decay": "auto",
+                        "torch_adam": true
+                    }
+                },
+                "scheduler": {
+                    "type": "WarmupDecayLR",
+                    "params": {
+                        "warmup_min_lr": "auto",
+                        "warmup_max_lr": "auto",
+                        "warmup_num_steps": "auto",
+                        "total_num_steps": "auto"
+                    }
+                },
+                "gradient_accumulation_steps": "auto",
+                "gradient_clipping": "auto",
+                "steps_per_print": 1000,
+                "train_batch_size": "auto",
+                "train_micro_batch_size_per_gpu": "auto",
+                "wall_clock_breakdown": false
+            }
+        } 
+    },
+    "model_params": {
+        "__meta__": {
+            "class_fullname": "pecos.xmr.reranker.model###RankingModel.ModelParams"
+        },
+        "encoder_config": {
+            "text_config": {
+                "model_type": "qwen2",
+                "name_or_path": "Qwen/Qwen2-7B",
+                "attn_implementation": "sdpa",
+                "trust_remote_code": true,
+                "token": null
+            },
+            "numr_config": null,
+            "text_pooling_type": "last",
+            "head_size_list": [128]
+        },
+        "model_modifier": {
+            "modifier_type": "peft",
+            "config_type": "LoraConfig" ,
+            "config": {
+                "r": 16,
+                "lora_alpha": 32,
+                "target_modules": ["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj"],
+                "modules_to_save": ["head_layers", "scorer"],
+                "lora_dropout": 0.1
+            }
+        },
+        "positive_passage_no_shuffle": false,
+        "negative_passage_no_shuffle": false,
+        "rerank_max_len": 196,
+        "query_prefix": "query: ",
+        "passage_prefix": "document: ",
+        "inp_id_col": "inp_id",
+        "lbl_idxs_col": "ret_idxs",
+        "score_col": "rel",
+        "keyword_col_name": "keywords",
+        "content_col_names": ["title", "contents"],
+        "append_eos_token": false,
+        "pad_to_multiple_of": 16
+    }
+}

--- a/examples/msmarco-rankllama/parquet_to_trec_eval.py
+++ b/examples/msmarco-rankllama/parquet_to_trec_eval.py
@@ -1,0 +1,36 @@
+
+import argparse
+import os
+import pandas as pd
+
+
+def main(args):
+    """
+    Combine all results from the results folder and write them to the output file.
+    """
+    result_files = [
+        os.path.join(args.input_parquet_path, x)
+        for x in os.listdir(args.input_parquet_path)
+    ]
+    all_results = pd.read_parquet(result_files[0])
+    for f in result_files[1:]:
+        all_results = pd.concat([all_results, pd.read_parquet(f)])
+    # sort all results by 'inp_id' and then 'score' in descending order    
+    all_results = all_results.sort_values(by=['inp_id', 'score'], ascending=[True, False])
+
+    cur_inp_id = None
+    with open(args.output_trec_path, "w") as fout:
+        for row in all_results.itertuples():
+            if cur_inp_id != row.inp_id:
+                cur_inp_id = row.inp_id
+                rank = 0
+            rank += 1
+            fout.write(f"{row.inp_id} Q0 {row.lbl_id} {rank} {row.score} dense\n")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-i", "--input-parquet-path", type=str, required=True)
+    parser.add_argument("-o", "--output-trec-path", type=str, required=True)
+    args = parser.parse_args()
+    main(args)

--- a/pecos/xmr/reranker/README.md
+++ b/pecos/xmr/reranker/README.md
@@ -4,22 +4,14 @@ This is a reranker for the PECOS XMR model. It is based on huggingface's transfo
 single process and distributed mode. It is based on the paper [Fine-Tuning LLaMA for Multi-Stage Text Retrieval](https://arxiv.org/abs/2310.08319).
 
 ## How to run
-### Single process
-To run the reranker in single process mode, you can use the following command:
+
+### Training
+To train the reranker, we suggest to use the `torchrun` command:
 
 ```bash
-python -m pecos.xmr.reranker.train --config_json_path <path_to_config_file>
-```
-
-### Distributed mode
-To run the reranker in distributed mode, you can use the following command to initialize the distributed configuration:
-```bash
-accelerate config
-```
-
-Then you can run the reranker using the following command:
-```bash
-accelerate launch -m pecos.xmr.reranker.train --config_json_path <path_to_config_file>
+torchrun --nnodes 1 --nproc-per-node 8 \
+    -m pecos.xmr.reranker.train \
+    --config_json_path <path_to_config_file>
 ```
 
 ### Predictions
@@ -28,112 +20,12 @@ To run the reranker in prediction mode, you can use the following command:
 python -m pecos.xmr.reranker.predict --config_json_path <path_to_config_file>
 ```
 
-## Configuration file
-
-### Training
-Here is an example of the configuration file for training:
-```json
-{
-  "train_params": {
-    "__meta__": {
-      "class_fullname": "pecos.xmr.reranker.model###RankingModel.TrainParams"
-    },
-    "target_data_folder": "/home/ec2-user/docker_disk/datasets/ms_marco_partitioned/target",
-    "input_data_folder":  "/home/ec2-user/docker_disk/datasets/ms_marco_partitioned/input",
-    "label_data_folder":  "/home/ec2-user/docker_disk/datasets/ms_marco_partitioned/label",
-    "training_args": {
-      "__meta__": {
-        "class_fullname": "pecos.xmr.reranker.trainer###RankLlamaTrainer.TrainingArgs"
-      },
-      "learning_rate": 1e-4,
-      "output_dir": "./ds_model",
-      "per_device_train_batch_size": 8,
-      "gradient_accumulation_steps": 8,
-      "max_steps": -1,
-      "logging_strategy": "steps",
-      "logging_first_step": false,
-      "logging_steps": 10,
-      "save_strategy": "steps",
-      "save_steps": 50,
-      "save_total_limit": 5,
-      "seed": 42,
-      "data_seed": 42,
-      "bf16": true,
-      "dataloader_num_workers": 2,
-      "dataloader_prefetch_factor": 10,
-      "gradient_checkpointing": true,
-      "train_group_size": 16
-    }
-  },
-  "model_params": {
-    "__meta__": {
-      "class_fullname": "pecos.xmr.reranker.model###RankingModel.ModelParams"
-    },
-    "encoder_args": {
-      "__meta__": {
-        "class_fullname": "pecos.xmr.reranker.model###CrossEncoder.Config"
-      },
-      "model_shortcut": "meta-llama/Llama-2-7b-hf",
-      "model_init_kwargs": {},
-      "model_modifier": {
-                    "modifier_type": "peft",
-                    "config_type": "LoraConfig" ,
-                    "config": {
-                        "r": 8,
-                        "lora_alpha": 64,
-                        "target_modules": ["q_proj", "v_proj"],
-                        "modules_to_save": ["score", "classifier"],
-                        "lora_dropout": 0.1
-                    }
-      }
-    },
-    "positive_passage_no_shuffle": false,
-    "negative_passage_no_shuffle": false,
-    "rerank_max_len": 196,
-    "query_prefix": "query: ",
-    "passage_prefix": "document: ",
-    "inp_id_col": "inp_id",
-    "lbl_idxs_col": "ret_idxs",
-    "score_col": "rel",
-    "keyword_col_name": "keywords",
-    "content_col_names": ["title", "contents"],
-    "append_eos_token": false,
-    "pad_to_multiple_of": 16
-  }
-}
-```
-
-### Prediction
-Following is the example of the configuration file for prediction:
-```json
-{
-    "model_name_or_path": "/tmp/pecosdev/ds_model",
-    "target_data_folder": "/home/ec2-user/docker_disk/datasets/msmarcoeval/target",
-    "input_data_folder":  "/home/ec2-user/docker_disk/datasets/msmarcoeval/input",
-    "label_data_folder":  "/home/ec2-user/docker_disk/datasets/msmarcoeval/label",
-    "output_dir": "/tmp/xmrout",
-    "per_device_eval_batch_size": 512,
-    "dataloader_num_workers": 1,
-    "dataloader_prefetch_factor": 10,
-    "rerank_max_len": 196,
-    "query_prefix": "query: ",
-    "passage_prefix": "document: ",
-    "inp_id_col": "inp_id",
-    "lbl_id_col": "lbl_id",
-    "keyword_col_name": "keywords",
-    "content_col_names": ["title", "contents"],
-    "append_eos_token": false,
-    "pad_to_multiple_of": 8,
-    "device": "cuda",
-    "model_init_kwargs": {
-        "device_map": "auto"
-    }
-}
-```
+## Config JSON Files
+See example training/predict JSON files in `pecos/examples/msmarco-rankllama` folders.
 
 ## Data Schema
-The column names for the data schema are configurable through the json configuration file. Following 
-are the various schemas that are supported by the reranker:
+The column names for the data schema are configurable through the json configuration file.
+Following are the various schemas that are supported by the reranker:
 
 (1) Learning Target Schema
 ```

--- a/pecos/xmr/reranker/data_utils.py
+++ b/pecos/xmr/reranker/data_utils.py
@@ -1,3 +1,4 @@
+import bisect
 import os
 import random
 from collections import OrderedDict
@@ -8,6 +9,143 @@ import pyarrow.parquet as pq
 from datasets import load_dataset
 
 import pecos
+
+
+def get_pairwise_batch(
+    batch,
+    inp_col,
+    lbl_col,
+    rel_col,
+    group_size,
+    pos_label_sampling="weighted",
+):
+    """
+    Convert listwise batch into pairwise batch by sampling two entrees
+    with distict rel_col per input
+
+    Example:
+        batch = {
+            "inp_col": ["q1", "q2"],
+            "lbl_col": [
+                ["p11", "p12", "p13"],
+                ["p21", "p22", "p23", "p24"],
+            ],
+            "rel_col": [
+                [1.0, 0.5, 0.1],
+                [0.9, 0.9, 0.7, 0.6],
+            ],
+        }
+        pairwise_batch = {
+            "inp_col": ["q1", "q1", "q2", "q2"],
+            "lbl_col": ["a11", "a13", "a22", "a23"],
+            "rel_col": [1.0, 0.1, 0.9, 0.7],
+        }
+
+    """
+
+    def sample_unequal_pair_from_array(data):
+        "sample a pair of indices from a decent sorted array"
+        non_min_sum = len(data) - 1
+        while data[non_min_sum] == data[-1]:
+            non_min_sum -= 1
+        # assert non_min_sum > 0, (non_min_sum, data)
+
+        if pos_label_sampling == "weighted":
+            psum = np.sum(data[: (non_min_sum + 1)])
+            pos_idx = np.random.choice(range(non_min_sum + 1), p=data[: (non_min_sum + 1)] / psum)
+        elif pos_label_sampling == "uniform":
+            pos_idx = np.random.randint(non_min_sum + 1)
+        else:
+            raise NotImplementedError(f"Unknown positive sampling method {pos_label_sampling}")
+
+        # neg_num = np.sum(data < data[pos_idx])
+        neg_start = pos_idx
+        while data[neg_start] == data[pos_idx]:
+            neg_start += 1
+
+        # assert neg_num > 0, (neg_num, data)
+        neg_idx = np.random.randint(neg_start, len(data))
+        return pos_idx, neg_idx
+
+    if group_size != 2:
+        raise ValueError(f"pairwise batch sampling assumes group_size==2")
+
+    pair_indices = [sample_unequal_pair_from_array(scores) for scores in batch[rel_col]]
+    pos_lbls = [alist[pa[0]] for alist, pa in zip(batch[lbl_col], pair_indices)]
+    neg_lbls = [alist[pa[1]] for alist, pa in zip(batch[lbl_col], pair_indices)]
+    pos_rels = [slist[pa[0]] for slist, pa in zip(batch[rel_col], pair_indices)]
+    neg_rels = [slist[pa[1]] for slist, pa in zip(batch[rel_col], pair_indices)]
+
+    return {
+        inp_col: np.repeat(batch[inp_col], group_size),
+        lbl_col: np.vstack([pos_lbls, neg_lbls]).T.flatten(),
+        rel_col: np.vstack([pos_rels, neg_rels]).T.flatten(),
+    }
+
+
+def get_listwise_batch(
+    batch,
+    inp_col,
+    lbl_col,
+    rel_col,
+    group_size,
+    pos_label_sampling="weighted",
+    neg_rel_val=0.0,
+):
+    """
+    Convert listwise batch into sampled listwise batch
+    we assume the group_size be smaller then len(lbl_col[i]), for all i
+
+    Example:
+        batch = {
+            "inp_col": ["q1", "q2"],
+            "lbl_col": [
+                ["p11", "p12", "p13", "p14"],
+                ["p21", "p22", "a23", "p24", "p25"],
+            ],
+            "rel_col": [
+                [0.8, 0.5, 0.0, 0.0],
+                [0.9, 0.0, 0.0, 0.0, 0.0],
+            ],
+        }
+
+        sampled listwise batch (group_size=3)
+        listwise_batch = {
+            "inp_col": ["q1", "q1", "q1", "q2", "q2", "q2"],
+            "lbl_col": ["p12", "p14", "p13", "p21", "q23", "q25"],
+            "rel_col": [0.5, 0.0, 0.0, 0.9, 0.0, 0.0],
+        }
+    """
+    if group_size < 2:
+        raise ValueError("listwise batch sampling assumes group_size >= 2")
+
+    all_lbl_list, all_rel_list = [], []
+    for lbl_arr, rel_arr in zip(batch[lbl_col], batch[rel_col]):
+        # note that bisect assumes lbl_arr/rel_arr are sorted ascendingly (by values in rel_arr)
+        # so we add negative sign to flip the order from descendingly to ascendingly,
+        # and find rightmost index (i.e., pos_ptr) whose value less than -neg_label_val.
+        # see https://docs.python.org/3/library/bisect.html
+        pos_ptr = bisect.bisect_left(-rel_arr, -neg_rel_val)
+
+        # sample 1 positive
+        indices = np.random.randint(0, high=pos_ptr, size=1).tolist()
+
+        # smaple group_size - 1 negatives
+        num_true_neg = min(len(lbl_arr) - pos_ptr, group_size - 1)
+        if num_true_neg > 0:
+            indices += np.random.randint(pos_ptr, high=len(lbl_arr), size=num_true_neg).tolist()
+        num_rand_neg = (group_size - 1) - num_true_neg
+        if num_rand_neg > 0:
+            assert NotImplementedError(f"within batch negative not support for Listwise Ranking!")
+
+        all_lbl_list.append(lbl_arr[indices].tolist())
+        all_rel_list.append(rel_arr[indices].tolist())
+    # end for loop
+    return {
+        inp_col: np.repeat(batch[inp_col], group_size),
+        lbl_col: np.vstack(all_lbl_list).flatten(),
+        rel_col: np.vstack(all_rel_list).flatten(),
+    }
 
 
 class RankingDataUtils(pecos.BaseClass):
@@ -59,7 +197,7 @@ class RankingDataUtils(pecos.BaseClass):
         ret_idxs: List[int],
         scores: List[float],
         table_stores,
-        train_group_size: int,
+        group_size: int,
         inp_prefix: str,
         passage_prefix: str,
         keyword_col_name: str,
@@ -73,7 +211,7 @@ class RankingDataUtils(pecos.BaseClass):
             ret_idxs: The retrieved indices
             scores: Scores for the retrieved indices
             table_stores: Dictionary of table stores for input and label data
-            train_group_size: The number of passages used to train for each query
+            group_size: The number of passages used to train for each query
             inp_prefix: The input prefix
             passage_prefix: The passage prefix
             keyword_col_name: The column name for the query text
@@ -97,17 +235,15 @@ class RankingDataUtils(pecos.BaseClass):
         random.shuffle(pos_idxs)
         random.shuffle(neg_idxs)
 
-        num_positives = train_group_size // 2
+        num_positives = group_size // 2
 
         all_selections = pos_idxs[:num_positives]
         num_positives = len(all_selections)
-        num_negatives = train_group_size - num_positives
+        num_negatives = group_size - num_positives
         all_selections.extend(neg_idxs[:num_negatives])
 
-        if len(all_selections) < train_group_size:
-            all_selections.extend(
-                random.choices(neg_idxs, k=train_group_size - len(all_selections))
-            )
+        if len(all_selections) < group_size:
+            all_selections.extend(random.choices(neg_idxs, k=group_size - len(all_selections)))
 
         all_scores = [s for s, _ in all_selections]
         all_pids = [pid for _, pid in all_selections]

--- a/pecos/xmr/reranker/trainer.py
+++ b/pecos/xmr/reranker/trainer.py
@@ -6,9 +6,18 @@ from dataclasses import dataclass
 from typing import Optional, Any, Tuple, Dict
 
 import torch
-from torch.utils.data import DataLoader
-from transformers import Trainer, TrainingArguments, HfArgumentParser
-
+import torch.nn as nn
+from torch.utils.data import DataLoader, IterableDataset
+from transformers import (
+    Trainer,
+    TrainingArguments,
+    HfArgumentParser,
+)
+from transformers.trainer_callback import (
+    TrainerCallback,
+    TrainerControl,
+    TrainerState,
+)
 import pecos
 
 PARAM_FILENAME: str = "param.json"
@@ -16,21 +25,112 @@ PARAM_FILENAME: str = "param.json"
 logger = logging.getLogger(__name__)
 
 
-class RankLlamaTrainer(Trainer, pecos.BaseClass):
-    """
-    Trainer class for the RankLlama model. This class extends the Trainer class.
-    """
+class PairwisePointwiseHybridLoss(nn.Module):
+    def __init__(self, pairwise_loss, pointwise_loss):
+        super(PairwisePointwiseHybridLoss, self).__init__()
+        self.pairwise_loss = pairwise_loss
+        self.pointwise_loss = pointwise_loss
 
-    loss_fn = torch.nn.CrossEntropyLoss(reduction="mean")
-    outer_model = None
+    def forward(self, preds, target, alpha=0.5):
+        """
+        Args:
+            preds (torch.Tensor): prediction of shape (B, 2)
+            target (torch.Tensor): gt target of shape (B, 2)
+                target[:, 0] corresponds to relevance scores of positive labels
+                target[:, 1] correspodns to relevance scores of negative labels
+        """
+        pairwise_target = torch.ones(preds.shape[0], device=preds.device).long()
+        loss1 = self.pairwise_loss(preds[:, 0], preds[:, 1], pairwise_target)
 
-    def __init__(self, *args, **kwargs):
-        self.outer_model = kwargs.pop("outer_model")
-        super(RankLlamaTrainer, self).__init__(*args, **kwargs)
+        if self.pointwise_loss is not None:
+            loss2 = self.pointwise_loss(preds.flatten(), target.flatten())
+            return alpha * loss1 + (1.0 - alpha) * loss2
+        else:
+            return loss1
+
+
+class ListwisePointwiseHybridLoss(nn.Module):
+    def __init__(self, listwise_loss, pointwise_loss):
+        super(ListwisePointwiseHybridLoss, self).__init__()
+        self.listwise_loss = listwise_loss
+        self.pointwise_loss = pointwise_loss
+
+    def forward(self, preds, target, alpha=0.5):
+        """
+        Args:
+            preds (torch.Tensor): prediction of shape (B, M)
+            target (torch.Tensor): gt target of shape (B, M)
+                target[:, 0]  corresponds to the relevance scores of positive labels
+                target[:, 1:] corresponds to the relevance scores of negative labels
+        """
+        listwise_target = torch.zeros(preds.shape[0], device=preds.device).long()
+        loss1 = self.listwise_loss(preds, listwise_target)
+
+        if self.pointwise_loss is not None:
+            loss2 = self.pointwise_loss(preds.flatten(), target.flatten())
+            return alpha * loss1 + (1.0 - alpha) * loss2
+        else:
+            return loss1
+
+
+LOSS_FN_DICT = {
+    "pairwise": PairwisePointwiseHybridLoss(
+        nn.MarginRankingLoss(reduction="mean", margin=0.1),
+        nn.MSELoss(reduction="mean"),
+    ),
+    "listwise": ListwisePointwiseHybridLoss(
+        nn.CrossEntropyLoss(reduction="mean"),
+        nn.BCEWithLogitsLoss(reduction="mean"),
+    ),
+}
+
+
+class LoggerCallback(TrainerCallback):
+    def on_epoch_begin(
+        self,
+        args: TrainingArguments,
+        state: TrainerState,
+        control: TrainerControl,
+        train_dataloader,
+        **kwargs,
+    ):
+        if isinstance(train_dataloader.dataset, IterableDataset):
+            train_dataloader._IterableDataset_len_called = None
+        else:
+            pass
+
+    def on_log(
+        self,
+        args: TrainingArguments,
+        state: TrainerState,
+        control: TrainerControl,
+        logs=None,
+        **kwargs,
+    ):
+        # avoid modifying the logs object as it is shared between callbacks
+        logs = copy.deepcopy(logs)
+        _ = logs.pop("total_flos", None)
+        # round numbers so that it looks better in console
+        if "loss" in logs:
+            logs["loss"] = round(logs["loss"], 6)
+        if "grad_norm" in logs:
+            logs["grad_norm"] = round(logs["grad_norm"], 6)
+        if "epoch" in logs:
+            logs["epoch"] = round(logs["epoch"], 2)
+        if state.is_world_process_zero:
+            logger.info(logs)
+
+
+class RankingTrainer(Trainer, pecos.BaseClass):
+    """
+    Trainer class for the pecos.xmr.reranker.RankingModel.
+    """
 
     @dataclass
     class TrainingArgs(TrainingArguments, pecos.BaseParams):
-        train_group_size: int = 8
+        loss_fn: str = "listwise"
+        loss_alpha: float = 1.0
+        group_size: int = 8
 
         @classmethod
         def from_dict(cls, param=None):
@@ -47,6 +147,14 @@ class RankLlamaTrainer(Trainer, pecos.BaseClass):
             d = super().to_dict()
             return self.append_meta(d) if with_meta else d
 
+    def __init__(self, *args, **kwargs):
+        param_to_save = kwargs.pop("param_to_save")
+        super(RankingTrainer, self).__init__(*args, **kwargs)
+
+        self.loss_fn = LOSS_FN_DICT[self.args.loss_fn]
+        self.loss_alpha = self.args.loss_alpha
+        self.param_to_save = param_to_save
+
     def get_train_dataloader(self) -> DataLoader:
         """
         Returns the training dataloader. This function is called by the Trainer class.
@@ -55,7 +163,7 @@ class RankLlamaTrainer(Trainer, pecos.BaseClass):
         prefetch_factor = prefetch_factor if prefetch_factor else 10
         return DataLoader(
             self.train_dataset,
-            batch_size=self.args.per_device_train_batch_size,
+            batch_size=self._train_batch_size,
             # Ensure that at least one worker is creating batches
             # parallel to the model compute
             num_workers=max(self.args.dataloader_num_workers, 1),
@@ -75,35 +183,18 @@ class RankLlamaTrainer(Trainer, pecos.BaseClass):
         if output_dir is not None:
             os.makedirs(output_dir, exist_ok=True)
             logger.info(f"Saving to {output_dir}")
-
-        outer_model: Any = self.outer_model
         super()._save(output_dir, state_dict)
 
         # save the config
-        param = {
-            "model": outer_model.__class__.__name__,
-            "model_params": outer_model.model_params.to_dict(),
-            "train_params": outer_model.train_params.to_dict(),
-        }
-
         output_dir = output_dir if output_dir is not None else self.args.output_dir
-
-        param = outer_model.append_meta(param)
         with open(os.path.join(output_dir, PARAM_FILENAME), "w", encoding="utf-8") as f:
-            f.write(json.dumps(param, indent=True))
-
-    def _prepare_inputs(self, inputs):
-        """
-        Prepare the inputs for the model. This function is called by the Trainer class. Converts the inputs to mps
-        tensors if available.
-        """
-        super_inputs = super(RankLlamaTrainer, self)._prepare_inputs(inputs)
-        if torch.backends.mps.is_available():
-            super_inputs = {k: v.to("mps") for k, v in super_inputs.items()}
-        return super_inputs
+            f.write(json.dumps(self.param_to_save, indent=True))
 
     def compute_loss(
-        self, model, inputs: Dict[str, Any], return_outputs: bool = False
+        self,
+        model,
+        inputs: Dict[str, Any],
+        return_outputs: bool = False,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """
         Compute the loss for the model. This function is called by the Trainer class.
@@ -112,16 +203,23 @@ class RankLlamaTrainer(Trainer, pecos.BaseClass):
             inputs: The inputs to the model
             return_outputs: Whether to return the outputs
         """
-        self.args: RankLlamaTrainer.TrainingArgs
-        train_group_size = self.args.train_group_size
-        if not train_group_size:
-            raise NotImplementedError("Cannot perform ranking without train group")
-        gt_scores = inputs["scores"].reshape(-1, train_group_size)
-        ranker_logits = model(**inputs["input"], return_dict=True).logits
-        batch_size = gt_scores.shape[0]
+        self.args: RankingTrainer.TrainingArgs
+        group_size = self.args.group_size
 
-        grouped_logits = ranker_logits.view(batch_size, -1)
-        assert grouped_logits.shape == gt_scores.shape
-        loss = self.loss_fn(grouped_logits, gt_scores)
+        # ground truth target
+        target = inputs["target"]
+        target = target.view(-1, group_size)  # [B, M]
+        batch_size = target.shape[0]
 
-        return (loss, ranker_logits) if return_outputs else loss
+        # model prediction scores
+        preds_1d = model(
+            input_ids=inputs["input_ids"],
+            attention_mask=inputs["attention_mask"],
+            numeric_inputs=inputs.get("numeric_inputs", None),
+            token_type_ids=inputs.get("token_type_ids", None),
+        ).scores
+        preds_2d = preds_1d.view(batch_size, -1)  # [B, M]
+        assert preds_2d.shape == target.shape
+
+        loss = self.loss_fn(preds_2d, target, alpha=self.loss_alpha)
+        return (loss, preds_1d) if return_outputs else loss


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Refactor the PECOS RankingModel class to support applications with multi-modal inputs,
such as Text and Numerical Inputs. 

*Example Usage*
See `pecos/examples/msmarco-rankllama/` for the text-only re-ranking applications.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.