### PR TITLE
Remove QEMU in build_pypi workflow

### DIFF
--- a/.github/build_pypi_wheel.sh
+++ b/.github/build_pypi_wheel.sh
@@ -33,7 +33,7 @@ WHEEL_NAME=$(ls $WHEEL_OUTPUT_FOLDER)
 echo "Temporary wheel: $(ls $WHEEL_OUTPUT_FOLDER)"
 auditwheel show $WHEEL_OUTPUT_FOLDER/$WHEEL_NAME
 
-echo "Auditing wheel to platform $PLAT..."
+echo "Auditing wheel to platform $DOCKER_IMG..."
 auditwheel repair $WHEEL_OUTPUT_FOLDER/$WHEEL_NAME -w $WHEEL_OUTPUT_FOLDER
 rm $WHEEL_OUTPUT_FOLDER/$WHEEL_NAME
 

--- a/.github/workflows/build_pypi.yml
+++ b/.github/workflows/build_pypi.yml
@@ -10,37 +10,38 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
-        build_platform: ["manylinux2014_x86_64", "manylinux2014_aarch64"]
+        platform: [ubuntu-22.04, ubuntu-22.04-arm]
+        include:
+          - image: "manylinux2014_x86_64"
+            platform: ubuntu-22.04
+          - image: "manylinux2014_aarch64"
+            platform: ubuntu-22.04-arm
 
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.platform }}
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
-      with:
-        platforms: all
-
     - name: Build Wheel
       env:
-        DOCKER_IMG: quay.io/pypa/${{ matrix.build_platform }}
+        DOCKER_IMG: quay.io/pypa/${{ matrix.image }}
         DOCKER_MNT: pypi_build
         WHEEL_DIR: wheel # wheel location
       run: |
         echo "Build wheel for PECOS using Python version ${{ matrix.python-version }}..."
         docker run --rm -v $(pwd):/$DOCKER_MNT \
-        --env PLAT=${{ matrix.build_platform }} --env PIP_VER=${{ matrix.python-version }} \
+        --env DOCKER_IMG=$DOCKER_IMG --env PIP_VER=${{ matrix.python-version }} \
         --env DOCKER_MNT=$DOCKER_MNT --env WHEEL_DIR=$WHEEL_DIR \
         $DOCKER_IMG /bin/bash /$DOCKER_MNT/.github/build_pypi_wheel.sh
 
     - name: Test Wheel
-      if: matrix.build_platform == 'manylinux2014_x86_64' # Only test for x86, aarch64 simulation too slow
       env:
         WHEEL_DIR: wheel # wheel location
       run: |


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Use GitHub ARM64 runner and remove QEMU in build_pypi workflow.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.