### PR TITLE
Fix ValueError in _divide_sub_cluster_jobs with numpy >= 1.24

### DIFF
--- a/pecos/distributed/xmc/base.py
+++ b/pecos/distributed/xmc/base.py
@@ -470,10 +470,17 @@ class DistClustering(object):
                 f"Some machines will be idle."
             )
 
-        # Numpy's array_split pads with empty array if len(sub_tree_assign_arr_list) < num_machine
-        grp_list = np.array_split(sub_tree_assign_arr_list, num_machine)
+        # Use plain Python list splitting instead of np.array_split to handle
+        # ragged arrays (sub-trees with different numbers of labels).
+        # np.array_split fails on numpy>=1.24 with inhomogeneous sequences.
+        n = len(sub_tree_assign_arr_list)
+        k, m = divmod(n, num_machine)
+        grp_list = [
+            sub_tree_assign_arr_list[i * k + min(i, m):(i + 1) * k + min(i + 1, m)]
+            for i in range(num_machine)
+        ]
 
-        return [grp.tolist() for grp in grp_list]
+        return grp_list
 
     def dist_get_cluster_chain(self, X, Y):
         """Distributed create cluster chain


### PR DESCRIPTION

## Fix `ValueError` in `_divide_sub_cluster_jobs` with numpy >= 1.24

### Issue

`DistClustering._divide_sub_cluster_jobs` in `pecos/distributed/xmc/base.py` crashes during distributed training with numpy >= 1.24:

```
File "pecos/distributed/xmc/base.py", line 474, in _divide_sub_cluster_jobs
    grp_list = np.array_split(sub_tree_assign_arr_list, num_machine)
ValueError: setting an array element with a sequence. The requested array has an 
inhomogeneous shape after 1 dimensions. The detected shape was (8,) + inhomogeneous part.
```

`sub_tree_assign_arr_list` is a list of arrays with different lengths (one per meta-tree leaf cluster, where each cluster has a different number of labels). `np.array_split` internally calls `np.asarray()` on this list, which in numpy < 1.24 silently created an object array, but in numpy >= 1.24 raises `ValueError` for ragged/inhomogeneous sequences.

This is triggered in distributed XMC training when `nr_splits` produces leaf clusters of unequal size, which is the common case for real-world data.

### Description of changes

Replaced `np.array_split(sub_tree_assign_arr_list, num_machine)` with a pure Python divmod-based list partitioning that:

- Handles variable-length (ragged) sub-tree assignment arrays naturally
- Preserves the same split semantics: divides `n` items into `num_machine` groups as evenly as possible, with the first `m` groups getting one extra item (where `n = k * num_machine + m`)
- Still produces empty lists for trailing groups when `len(sub_tree_assign_arr_list) < num_machine`
- Returns `list[list]` directly instead of converting through numpy arrays and back via `.tolist()`
- Works with all numpy versions

### Testing

No test changes required — existing `test_dist_clustering` passes with the fix.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.